### PR TITLE
Account for density in divergence check

### DIFF
--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -164,7 +164,7 @@ contains
   subroutine chkdiv
 
     use modglobal, only : i1,j1,kmax,dx,dy,dzf
-    use modfields, only : um,vm,wm,rhobf,rhobh
+    use modfields, only : um,vm,wm
     use modmpi,    only : myid,comm3d,mpi_sum,mpi_max,my_real,mpierr
     implicit none
 
@@ -183,9 +183,9 @@ contains
     do j=2,j1
     do i=2,i1
       div = &
-                rhobf(k) * (um(i+1,j,k) - um(i,j,k) )/dx + &
-                rhobf(k) * (vm(i,j+1,k) - vm(i,j,k) )/dy + &
-                (rhobh(k+1)*wm(i,j,k+1) - rhobh(k)*wm(i,j,k) )/dzf(k)
+                (um(i+1,j,k) - um(i,j,k) )/dx + &
+                (vm(i,j+1,k) - vm(i,j,k) )/dy + &
+                (wm(i,j,k+1) - wm(i,j,k) )/dzf(k)
       divmaxl = max(divmaxl,abs(div))
       divtotl = divtotl + div*dx*dy*dzf(k)
     end do

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -164,7 +164,7 @@ contains
   subroutine chkdiv
 
     use modglobal, only : i1,j1,kmax,dx,dy,dzf
-    use modfields, only : um,vm,wm
+    use modfields, only : um,vm,wm,rhobf,rhobh
     use modmpi,    only : myid,comm3d,mpi_sum,mpi_max,my_real,mpierr
     implicit none
 
@@ -185,7 +185,7 @@ contains
       div = &
                 (um(i+1,j,k) - um(i,j,k) )/dx + &
                 (vm(i,j+1,k) - vm(i,j,k) )/dy + &
-                (wm(i,j,k+1) - wm(i,j,k) )/dzf(k)
+                (rhobh(k+1)*wm(i,j,k+1) - rhobh(k)*wm(i,j,k) )/(rhobf(k)*dzf(k))
       divmaxl = max(divmaxl,abs(div))
       divtotl = divtotl + div*dx*dy*dzf(k)
     end do

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -164,7 +164,7 @@ contains
   subroutine chkdiv
 
     use modglobal, only : i1,j1,kmax,dx,dy,dzf
-    use modfields, only : um,vm,wm
+    use modfields, only : um,vm,wm,rhobf,rhobh
     use modmpi,    only : myid,comm3d,mpi_sum,mpi_max,my_real,mpierr
     implicit none
 
@@ -183,9 +183,9 @@ contains
     do j=2,j1
     do i=2,i1
       div = &
-                (um(i+1,j,k) - um(i,j,k) )/dx + &
-                (vm(i,j+1,k) - vm(i,j,k) )/dy + &
-                (wm(i,j,k+1) - wm(i,j,k) )/dzf(k)
+                rhobf(k) * (um(i+1,j,k) - um(i,j,k) )/dx + &
+                rhobf(k) * (vm(i,j+1,k) - vm(i,j,k) )/dy + &
+                (rhobh(k+1)*wm(i,j,k+1) - rhobh(k)*wm(i,j,k) )/dzf(k)
       divmaxl = max(divmaxl,abs(div))
       divtotl = divtotl + div*dx*dy*dzf(k)
     end do


### PR DESCRIPTION
Density was not accounted for in the divergence check; it should be `d(rho*u_i)/dx_i` instead of  `d(u_i)/dx_i`