### PR TITLE
include kind specifier in ceiling function

### DIFF
--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -456,7 +456,7 @@ contains
       end do
     end if
     tnextrestart = trestart/tres
-    timeleft=ceiling(runtime/tres)
+    timeleft=ceiling(runtime/tres, longint)
 
   end subroutine initglobal
 !> Clean up when leaving the run

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -358,7 +358,7 @@ contains
                                   rtimee,timee,ntimee,ntrun,btime,dt_lim,nsv,&
                                   zf,dzf,dzh,rv,rd,cp,rlv,pref0,om23_gs,&
                                   ijtot,cu,cv,e12min,dzh,cexpnr,ifinput,lwarmstart,itrestart,&
-                                  trestart, ladaptive,llsadv,tnextrestart
+                                  trestart, ladaptive,llsadv,tnextrestart,longint
     use modsubgrid,        only : ekm,ekh
     use modsurfdata,       only : wsvsurf, &
                                   thls,tskin,tskinm,tsoil,tsoilm,phiw,phiwm,Wl,Wlm,thvs,qts,isurf,svs,obl,oblav,&
@@ -733,7 +733,7 @@ contains
     ntrun   = 0
     rtimee  = real(timee)*tres
     ntimee  = nint(timee/dtmax)
-    itrestart = floor(trestart/tres)
+    itrestart = floor(trestart/tres, longint)
     tnextrestart = btime + itrestart
     deallocate (height,th0av)
 


### PR DESCRIPTION
timeleft is longint, however ceiling (at least on gfortran 8.1.1) defaults to int32 leading to an incorrect value
(due to overflow) of timeleft.

fix is to include kind specifier in ceiling