### PR TITLE
cmake: fix minimum required version for git-version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 
 ## Project parameters
 PROJECT(DALES Fortran)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.2)
 set(VERSION_MAJOR "4")
 set(VERSION_MINOR "2")
 set(VERSION_PATCH "1")
@@ -202,7 +202,7 @@ if(NOT CASE)
       FORCE)
 endif()
 
-### Add case specific file 
+### Add case specific file
 FILE(GLOB usrfile "${CMAKE_CURRENT_SOURCE_DIR}/cases/${CASE}/moduser.f90")
 if(usrfile STREQUAL "")
   set(usrfile "${CMAKE_CURRENT_SOURCE_DIR}/cases/standard/moduser.f90")


### PR DESCRIPTION
The option BYPRODUCTS of add_custom_target has been available since
CMake 3.2.
https://cmake.org/cmake/help/v3.2/command/add_custom_target.html

This has been introduced by commit
5efafbaed9f0482d106ccaae248a6276ae7a7a25.