### PR TITLE
proposing a revised Deardorff SGS TKE scheme

### DIFF
--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -36,7 +36,7 @@ save
 
 contains
   subroutine initsubgrid
-    use modglobal, only : ih,i1,jh,j1,k1,delta,zf,fkar,pi
+    use modglobal, only : ih,i1,jh,j1,k1,delta,zh,zf,fkar,pi
     use modmpi, only : myid
 
     implicit none
@@ -200,7 +200,7 @@ contains
 !                                                                 |
 !-----------------------------------------------------------------|
 
-  use modglobal,   only : i1,j1,kmax,k1,ih,jh,i2,j2,delta,ekmin,grav,zf,fkar,deltai, &
+  use modglobal,   only : i1,j1,kmax,k1,ih,jh,i2,j2,delta,ekmin,grav,zh,zf,fkar,deltai, &
                           dxi,dyi,dzf,dzh
   use modfields,   only : dthvdz,e120,u0,v0,w0,thvf
   use modsurfdata, only : dudz,dvdz,z0m
@@ -307,12 +307,12 @@ contains
             ekm(i,j,k) = max(ekm(i,j,k),ekmin)
             ekh(i,j,k) = max(ekh(i,j,k),ekmin)
           else
-             ! zlt(i,j,k) = min(delta(k),cn*e120(i,j,k)/sqrt(grav/thvf(k)*abs(dthvdz(i,j,k))))
+             zlt(i,j,k) = 1/(1/(0.4*zh(k))+1/(cn*e120(i,j,k)/sqrt(grav/thvf(k)*abs(dthvdz(i,j,k)))))
              ! faster calculation: evaluate sqrt only if the second argument is actually smaller
-             zlt(i,j,k) = delta(k)
-             if ( grav*abs(dthvdz(i,j,k)) * delta(k)**2 > (cn*e120(i,j,k))**2 * thvf(k) ) then
-                zlt(i,j,k) = cn*e120(i,j,k)/sqrt(grav/thvf(k)*abs(dthvdz(i,j,k)))
-             end if
+             ! zlt(i,j,k) = delta(k)
+             ! if ( grav*abs(dthvdz(i,j,k)) * delta(k)**2 > (cn*e120(i,j,k))**2 * thvf(k) ) then
+             !    zlt(i,j,k) = cn*e120(i,j,k)/sqrt(grav/thvf(k)*abs(dthvdz(i,j,k)))
+             ! end if
              
             if (lmason) zlt(i,j,k) = (1. / zlt(i,j,k) ** nmason + 1. / ( fkar * (zf(k) + z0m(i,j)))**nmason) ** (-1./nmason)
 

--- a/src/modtimedep.f90
+++ b/src/modtimedep.f90
@@ -432,7 +432,7 @@ contains
     do while(rtimee>timeflux(t))
       t=t+1
     end do
-    if (rtimee>timeflux(t)) then
+    if (rtimee>timeflux(t-1)) then
       t=t-1
     endif
 


### PR DESCRIPTION
Hi I would like to add a revise Deardorff SGS TKE scheme to the repository ([publication](https://arxiv.org/abs/2003.09463) is  provisionally accepted with minor revisions in Boundary Layer Meteorology).

The main revision is from  $$\lambda = min(\Delta, L_b)$$ to $$\frac{1}{\lambda}=\frac{1}{\kappa z}+\frac{1}{L_{b}}$$ 

There are changes in three files:
modbudget.f90: changes to add output of mixing length scale 

modsubgrid.f90: changes to parameterization of $$\lambda$$

modtimedep.f90: changes to fix a small bugs which is already addressed in branch to4.3_Fredrik

