### PR TITLE
Feature/explicit interface

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,104 @@
+# This is a basic workflow to compile DALES
+
+name: DALES compilation CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events
+  push:
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: ["gnu", "intel"]
+        fftw:    ["", "-DUSE_FFTW=T"]
+        hypre:   ["" ]
+        
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name : Install OneApi
+        if: matrix.toolchain == 'intel' 
+        run: |
+          # use wget to fetch the Intel repository public key
+          cd /tmp
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          # add to your apt sources keyring so that archives signed with this key will be trusted.
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          # remove the public key
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB 
+
+          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+
+          sudo apt install -y intel-oneapi-mpi-devel intel-oneapi-compiler-fortran
+
+          # localpc_ifort uses mpif90, which breaks, therefore we use CARTESIUS,
+          # which utilizes mpiifort which works
+          echo "SYST=CARTESIUS" >> $GITHUB_ENV 
+
+
+      - name: Install common dependencies
+        run: |
+          # Enable sources for netcdff-dev
+          sudo sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"
+
+          sudo apt-get update
+          sudo apt-get install -y cmake libfftw3-dev libhypre-dev libnetcdf-dev
+
+      - name: Install Intel depencencies
+        if: matrix.toolchain == 'intel' 
+        run: |
+          if [[ -f /opt/intel/oneapi/setvars.sh ]]; then
+            source /opt/intel/oneapi/setvars.sh
+          fi
+          
+          sudo apt-get install devscripts
+          sudo apt-get build-dep libnetcdff-dev
+
+          #Customize libnetcdff
+          apt-get source libnetcdff-dev
+          cd netcdf-fortran-*/
+          echo "override_dh_shlibdeps:" >> debian/rules
+          echo -e "\tdh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info" >> debian/rules
+
+          export F77=ifort
+          export FC=ifort
+          export F90=ifort
+          export FFLAGS='-O3 -xHost -ip -no-prec-div -static-intel'
+
+          debuild --no-lintian --preserve-env --preserve-envvar PATH -b -uc -us -ui -j2
+
+          cd ../
+          sudo dpkg -i *.deb
+
+      - name: Install Gnu dependencies
+        if: matrix.toolchain == 'gnu'
+        run: |
+            sudo apt-get install -y libopenmpi-dev libnetcdff-dev
+
+      - name : Set up Build
+        run: |
+          if [[ -f /opt/intel/oneapi/setvars.sh ]]; then
+            source /opt/intel/oneapi/setvars.sh
+          fi
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=DEBUG ${{ matrix.fftw }} ${{ matrix.hypre }} ../
+      - name : Build
+        run: |
+          if [[ -f /opt/intel/oneapi/setvars.sh ]]; then
+            source /opt/intel/oneapi/setvars.sh
+          fi
+          cd build
+          make -j2 dales4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ elseif("$ENV{SYST}" STREQUAL "HYDRA")
   set(CMAKE_Fortran_FLAGS_DEBUG "-traceback -fpe1 -O0 -g -check all" CACHE STRING "")
 elseif("$ENV{SYST}" STREQUAL "FEDORA")
   set(CMAKE_Fortran_COMPILER "mpif90")
-  set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -fdefault-double-8 -march=native -malign-double -ffree-line-length-none -I /usr/lib64/gfortran/modules/mpich/ -std=legacy" CACHE STRING "")
+  set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -fdefault-double-8 -march=native -malign-double -ffree-line-length-none -I /usr/lib64/gfortran/modules/mpich/ -std=gnu -Werror=implicit-interface" CACHE STRING "")
   set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -O3" CACHE STRING "")
   set (CMAKE_Fortran_FLAGS_DEBUG   "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
   set (CMAKE_Fortran_FLAGS_DEV     "-fbounds-check -fbacktrace -fno-f2c -O3 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
@@ -49,7 +49,7 @@ elseif("$ENV{SYST}" STREQUAL "ECMWF-gnu")
   set(CMAKE_Fortran_FLAGS_DEBUG   "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
 elseif("$ENV{SYST}" STREQUAL "gnu-fast")
   set(CMAKE_Fortran_COMPILER "mpif90")
-  set(CMAKE_Fortran_FLAGS "-W -Wall -fdefault-real-8 -fdefault-double-8 -march=native -malign-double -ffree-line-length-none -std=legacy" CACHE STRING "")
+  set(CMAKE_Fortran_FLAGS "-W -Wall -fdefault-real-8 -fdefault-double-8 -march=native -malign-double -ffree-line-length-none -std=gnu -Werror=implicit-interface" CACHE STRING "")
   set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -Ofast -g -fbacktrace" CACHE STRING "")
   set (CMAKE_Fortran_FLAGS_DEBUG   "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
 elseif("$ENV{SYST}" STREQUAL "lisa-intel")
@@ -74,7 +74,7 @@ elseif("$ENV{SYST}" STREQUAL "NO_OVERRIDES")
    # don't set any compilation flags here, allows setting them outside CMake
 else()
   set(CMAKE_Fortran_COMPILER "mpif90")
-  set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -fdefault-double-8 -march=native -malign-double -ffree-line-length-none -std=legacy" CACHE STRING "")
+  set(CMAKE_Fortran_FLAGS "-fdefault-real-8 -fdefault-double-8 -march=native -malign-double -ffree-line-length-none -std=gnu -Werror=implicit-interface" CACHE STRING "")
   set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -O3" CACHE STRING "")
   set (CMAKE_Fortran_FLAGS_DEBUG   "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
 endif()
@@ -82,6 +82,7 @@ endif()
 # On compiler options
 # June 2020: added -std=legacy to gfortran for compatibility with gfortran 10, which introduced stricter type checking
 # the old FFT code from Netlib/FFTPACK does not compile with gfortran 10 without this flag.
+# March 2021: fixed interfaces and removed -std=legacy
 
 # For GCC based compilers:
 #  * -march=native   : compile for the current CPU, allows use of modern AVX etc.

--- a/src/advec_2nd.f90
+++ b/src/advec_2nd.f90
@@ -29,6 +29,8 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 
+module advec_2nd
+contains
 !> Advection at cell center
 subroutine advecc_2nd(putin,putout)
 
@@ -438,3 +440,4 @@ subroutine advecw_2nd(putin,putout)
 
 
 end subroutine advecw_2nd
+end module advec_2nd

--- a/src/advec_52.f90
+++ b/src/advec_52.f90
@@ -33,6 +33,8 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 
+module advec_52
+contains
 !> Advection at cell center
 subroutine advecc_52(putin, putout)
 
@@ -549,3 +551,4 @@ subroutine advecw_52(putin, putout)
 
      
 end subroutine advecw_52
+end module advec_52

--- a/src/advec_5th.f90
+++ b/src/advec_5th.f90
@@ -33,6 +33,8 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 
+module advec_5th
+contains
 !> Advection at cell center
 subroutine advecc_5th(putin, putout)
 
@@ -818,3 +820,4 @@ end do
   !end if
 
 end subroutine advecw_5th
+end module advec_5th

--- a/src/advec_62.f90
+++ b/src/advec_62.f90
@@ -28,6 +28,8 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 
+module advec_62
+contains
 !> Advection at cell center
 subroutine advecc_62(putin, putout)
 
@@ -481,3 +483,4 @@ subroutine advecw_62(putin, putout)
      end do
 
 end subroutine advecw_62
+end module advec_62

--- a/src/advec_6th.f90
+++ b/src/advec_6th.f90
@@ -27,6 +27,8 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 
+module advec_6th
+contains
 !> Advection at cell center
 subroutine advecc_6th(putin, putout)
 
@@ -704,3 +706,4 @@ subroutine advecw_6th(putin, putout)
     end do
 
 end subroutine advecw_6th
+end module advec_6th

--- a/src/advec_kappa.f90
+++ b/src/advec_kappa.f90
@@ -45,6 +45,8 @@
 !
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
+module advec_kappa
+contains
 
 subroutine advecc_kappa(putin,putout)
   use modglobal, only : i1,i2,ih,j1,j2,jh,k1,kmax,dxi,dyi,dzf
@@ -213,7 +215,6 @@ subroutine advecc_kappa_old(putin,putout)
   use modglobal, only : i1,i2,ih,j1,j2,jh,k1,kmax,dxi,dyi,dzf
   use modfields, only : u0, v0, w0, rhobf
   implicit none
-  real,external :: rlim
   real, dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in) :: putin
   real, dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: putout
   real      d1,d2,cf
@@ -302,7 +303,6 @@ subroutine  halflev_kappa(putin,putout)
   use modglobal, only : i1,ih,j1,jh,k1
     use modfields, only : w0, rhobf, rhobh
     implicit none
-    real,external :: rlim
     real, dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in) :: putin
     real, dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: putout
     real      d1,d2,cf
@@ -359,3 +359,4 @@ subroutine  halflev_kappa(putin,putout)
 
 
 
+end module advec_kappa

--- a/src/advec_upw.f90
+++ b/src/advec_upw.f90
@@ -20,6 +20,8 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 
+module advec_upw
+contains
 !> Advection at cell center
 subroutine advecc_upw(putin,putout)
 
@@ -107,4 +109,4 @@ subroutine advecc_upw(putin,putout)
   enddo
 
 end subroutine advecc_upw
-
+end module advec_upw

--- a/src/daleslib.f90
+++ b/src/daleslib.f90
@@ -462,6 +462,7 @@ module daleslib
             !use modprojection,     only : projection
             use modchem,            only : twostep
             use modcanopy,          only : canopy
+            use modadvection,       only : advection
 
             implicit none
 
@@ -799,7 +800,7 @@ module daleslib
 
     ! Counts the profile of saturated grid cell fraction and scatters the result to all processes
     function gathersatfrac(Ag) result(ret)
-      use mpi, only: MPI_SUM, MPI_IN_PLACE
+      use mpi
       use modmpi, only: comm3d, my_real, nprocs
       use modglobal,   only : i1, j1
       use modfields, only: ql0

--- a/src/fftnew.f90
+++ b/src/fftnew.f90
@@ -17,6 +17,8 @@
 !
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
+module fftnew
+contains
 
   subroutine RADB2 (IDO,L1,CC,CH,WA1)
       DIMENSION       CC(IDO,2,L1)           ,CH(IDO,L1,2), WA1(IDO-1)
@@ -728,6 +730,7 @@
   end
 
   subroutine RFFTB1 (N,C,CH,WA,IFAC)
+    REAL ::  IFAC
       DIMENSION       CH(N)      ,C(N)       ,WA(N+1)      ,IFAC(2*N+1)
   NF = IFAC(2)
   NA = 0
@@ -806,6 +809,7 @@
   end
 
   subroutine RFFTF1 (N,C,CH,WA,IFAC)
+    real :: IFAC
       DIMENSION       CH(N)      ,C(N)       ,WA(N+1)      ,IFAC(2*N+1)
   NF = IFAC(2)
   NA = 1
@@ -883,6 +887,7 @@
   end
 
   subroutine RFFTI1 (N,WA,IFAC)
+  real :: IFAC
   logical firstloop
   DIMENSION       WA(N+1)      ,IFAC(2*N+1)    ,NTRYH(4)
   DATA NTRYH(1),NTRYH(2),NTRYH(3),NTRYH(4)/4,2,3,5/
@@ -955,3 +960,4 @@
   end do
   return
   end
+end module fftnew

--- a/src/fftnew.f90
+++ b/src/fftnew.f90
@@ -18,9 +18,68 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 module fftnew
+use iso_fortran_env, only : real64, int64
+implicit real(real64)   (a-h)
+implicit real(real64)   (o-z)
+implicit integer(int64) (i-n)
 contains
 
+
+  subroutine RFFTB (N,R,WSAVE)
+    interface 
+      subroutine RFFTB1 (N, C, CH, WA, WFAC)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+      DIMENSION       CH(N)      ,C(N)
+      end subroutine
+    end interface 
+      DIMENSION       R(1)       ,WSAVE(2*N+1)
+  if (N == 1) return
+  call RFFTB1 (N,R,WSAVE,WSAVE(N+1),WSAVE(2*N+1))
+  return
+  end
+
+
+  subroutine RFFTF (N,R,WSAVE)
+    interface 
+      subroutine RFFTF1 (N, C, CH, WA, WFAC)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+      DIMENSION       CH(N)      ,C(N)
+      end subroutine
+    end interface 
+      DIMENSION       R(1)       ,WSAVE(2*N+1)
+  if (N == 1) return
+  call RFFTF1 (N,R,WSAVE,WSAVE(N+1),WSAVE(2*N+1))
+  return
+  end
+
+
+  subroutine RFFTI (N,WSAVE)
+    interface 
+      subroutine RFFTI1 (N, WA, WFAC)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+      end subroutine
+    end interface 
+      DIMENSION       WSAVE(2*N+1)
+  if (N == 1) return
+  call RFFTI1 (N,WSAVE(N+1),WSAVE(2*N+1))
+  return
+  end
+
+end module fftnew
   subroutine RADB2 (IDO,L1,CC,CH,WA1)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION       CC(IDO,2,L1)           ,CH(IDO,L1,2), WA1(IDO-1)
   do K=1,L1
      CH(1,K,1) = CC(1,1,K)+CC(IDO,2,K)
@@ -52,6 +111,10 @@ contains
   end
 
   subroutine RADB3 (IDO,L1,CC,CH,WA1,WA2)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION       CC(IDO,3,L1) ,CH(IDO,L1,3) ,WA1(1)     ,WA2(1)
   DATA TAUR,TAUI /-.5,.866025403784439/
   do K=1,L1
@@ -89,6 +152,10 @@ contains
   end
 
   subroutine RADB4 (IDO,L1,CC,CH,WA1,WA2,WA3)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION       CC(IDO,4,L1),CH(IDO,L1,4),WA1(IDO-1),WA2(IDO-1),WA3(IDO-1)
   DATA SQRT2 /1.414213562373095/
   do K=1,L1
@@ -148,6 +215,10 @@ contains
   end
 
   subroutine RADB5 (IDO,L1,CC,CH,WA1,WA2,WA3,WA4)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION  CC(IDO,5,L1),CH(IDO,L1,5),WA1(1),WA2(1),WA3(1),WA4(1)
       DATA TR11,TI11,TR12,TI12 /.309016994374947,.951056516295154,-.809016994374947,.587785252292473/
   do K=1,L1
@@ -210,6 +281,10 @@ contains
   end
 
   subroutine RADBG (IDO,IP,L1,IDL1,CC,C1,C2,CH,CH2,WA)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION  CH(IDO,L1,IP),CC(IDO,IP,L1),C1(IDO,L1,IP),C2(IDL1,IP), CH2(IDL1,IP) ,WA(1)
   DATA TPI/6.28318530717959/
   ARG = TPI/FLOAT(IP)
@@ -374,6 +449,10 @@ contains
   end
 
   subroutine RADF2 (IDO,L1,CC,CH,WA1)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION       CH(IDO,2,L1),CC(IDO,L1,2),WA1(IDO-1)
   do K=1,L1
      CH(1,1,K) = CC(1,K,1)+CC(1,K,2)
@@ -404,6 +483,10 @@ contains
   end
 
   subroutine RADF3 (IDO,L1,CC,CH,WA1,WA2)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION       CH(IDO,3,L1),CC(IDO,L1,3), WA1(1)     ,WA2(1)
   DATA TAUR,TAUI /-.5,.866025403784439/
   do K=1,L1
@@ -439,6 +522,10 @@ contains
   end
 
   subroutine RADF4 (IDO,L1,CC,CH,WA1,WA2,WA3)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION       CC(IDO,L1,4),CH(IDO,4,L1), WA1(IDO-1)     ,WA2(IDO-1)     ,WA3(IDO-1)
   DATA HSQT2 /.7071067811865475/
   do K=1,L1
@@ -494,6 +581,10 @@ contains
   end
 
   subroutine RADF5 (IDO,L1,CC,CH,WA1,WA2,WA3,WA4)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION       CC(IDO,L1,5),CH(IDO,5,L1),WA1(1)     ,WA2(1)     ,WA3(1)     ,WA4(1)
       DATA TR11,TI11,TR12,TI12 /.309016994374947,.951056516295154,-.809016994374947,.587785252292473/
   do K=1,L1
@@ -552,6 +643,10 @@ contains
   end
 
   subroutine RADFG (IDO,IP,L1,IDL1,CC,C1,C2,CH,CH2,WA)
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
       DIMENSION CH(IDO,L1,IP),CC(IDO,IP,L1),C1(IDO,L1,IP),C2(IDL1,IP),CH2(IDL1,IP),WA(1)
   DATA TPI/6.28318530717959/
   ARG = TPI/FLOAT(IP)
@@ -722,15 +817,50 @@ contains
   return
   end
 
-  subroutine RFFTB (N,R,WSAVE)
-      DIMENSION       R(1)       ,WSAVE(2*N+1)
-  if (N == 1) return
-  call RFFTB1 (N,R,WSAVE,WSAVE(N+1),WSAVE(2*N+1))
-  return
-  end
+
 
   subroutine RFFTB1 (N,C,CH,WA,IFAC)
-    REAL ::  IFAC
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
+      interface
+        subroutine RADB2 (IDO,L1,CC,CH,WA1)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION       CC(IDO,2,L1),CH(IDO,L1,2), WA1(IDO-1)
+        end subroutine
+        subroutine RADB3 (IDO,L1,CC,CH,WA1,WA2)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION       CC(IDO,3,L1),CH(IDO,L1,3) ,WA1(1)     ,WA2(1)
+        end subroutine
+        subroutine RADB4 (IDO,L1,CC,CH,WA1,WA2,WA3)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION CC(IDO,4,L1),CH(IDO,L1,4),WA1(IDO-1),WA2(IDO-1),WA3(IDO-1)
+        end subroutine
+        subroutine RADB5 (IDO,L1,CC,CH,WA1,WA2,WA3,WA4)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION  CC(IDO,5,L1),CH(IDO,L1,5),WA1(1),WA2(1),WA3(1),WA4(1)
+        end subroutine
+        subroutine RADBG (IDO,IP,L1,IDL1,CC,C1,C2,CH,CH2,WA)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION CH(IDO,L1,IP),CC(IDO,IP,L1),C1(IDO,L1,IP),C2(IDL1,IP), CH2(IDL1,IP) ,WA(1)
+        end subroutine
+      end interface
       DIMENSION       CH(N)      ,C(N)       ,WA(N+1)      ,IFAC(2*N+1)
   NF = IFAC(2)
   NA = 0
@@ -800,16 +930,48 @@ contains
   end do
   return
   end
-
-  subroutine RFFTF (N,R,WSAVE)
-      DIMENSION       R(1)       ,WSAVE(2*N+1)
-  if (N == 1) return
-  call RFFTF1 (N,R,WSAVE,WSAVE(N+1),WSAVE(2*N+1))
-  return
-  end
-
   subroutine RFFTF1 (N,C,CH,WA,IFAC)
-    real :: IFAC
+      use iso_fortran_env, only : real64, int64
+      implicit real(real64)   (a-h)
+      implicit real(real64)   (o-z)
+      implicit integer(int64) (i-n)
+      interface
+        subroutine RADF2 (IDO,L1,CC,CH,WA1)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION       CH(IDO,2,L1),CC(IDO,L1,2),WA1(IDO-1)
+        end subroutine
+        subroutine RADF3 (IDO,L1,CC,CH,WA1,WA2)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION       CH(IDO,3,L1),CC(IDO,L1,3), WA1(1)     ,WA2(1)
+        end subroutine
+        subroutine RADF4 (IDO,L1,CC,CH,WA1,WA2,WA3)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION CC(IDO,L1,4),CH(IDO,4,L1), WA1(IDO-1), WA2(IDO-1), WA3(IDO-1)
+        end subroutine
+        subroutine RADF5 (IDO,L1,CC,CH,WA1,WA2,WA3,WA4)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION       CC(IDO,L1,5),CH(IDO,5,L1),WA1(1)     ,WA2(1)     ,WA3(1)     ,WA4(1)
+        end subroutine
+        subroutine RADFG (IDO,IP,L1,IDL1,CC,C1,C2,CH,CH2,WA)
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
+        DIMENSION CH(IDO,L1,IP),CC(IDO,IP,L1),C1(IDO,L1,IP),C2(IDL1,IP),CH2(IDL1,IP),WA(1)
+        end subroutine
+      end interface
       DIMENSION       CH(N)      ,C(N)       ,WA(N+1)      ,IFAC(2*N+1)
   NF = IFAC(2)
   NA = 1
@@ -879,15 +1041,11 @@ contains
   return
   end
 
-  subroutine RFFTI (N,WSAVE)
-      DIMENSION       WSAVE(2*N+1)
-  if (N == 1) return
-  call RFFTI1 (N,WSAVE(N+1),WSAVE(2*N+1))
-  return
-  end
-
   subroutine RFFTI1 (N,WA,IFAC)
-  real :: IFAC
+        use iso_fortran_env, only : real64, int64
+        implicit real(real64)   (a-h)
+        implicit real(real64)   (o-z)
+        implicit integer(int64) (i-n)
   logical firstloop
   DIMENSION       WA(N+1)      ,IFAC(2*N+1)    ,NTRYH(4)
   DATA NTRYH(1),NTRYH(2),NTRYH(3),NTRYH(4)/4,2,3,5/
@@ -960,4 +1118,3 @@ contains
   end do
   return
   end
-end module fftnew

--- a/src/modadvection.f90
+++ b/src/modadvection.f90
@@ -24,15 +24,24 @@
 !  Copyright 1993-2009 Delft University of Technology, Wageningen University, Utrecht University, KNMI
 !
 
+module modadvection
+contains
 !> Advection redirection function
 subroutine advection
 
-  use modglobal,  only : lmoist, nsv, iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv, &
-                         iadv_cd2,iadv_5th,iadv_52,iadv_cd6,iadv_62,iadv_kappa,iadv_upw,iadv_hybrid,iadv_hybrid_f,iadv_null,leq
-  use modfields,  only : u0,up,v0,vp,w0,wp,e120,e12p,thl0,thlp,qt0,qtp,sv0,svp
-  use modsubgrid, only : lsmagorinsky
-  use advec_hybrid, only : advecc_hybrid
+  use modglobal,      only : lmoist, nsv, iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv, &
+                             iadv_cd2,iadv_5th,iadv_52,iadv_cd6,iadv_62,iadv_kappa,iadv_upw,iadv_hybrid,iadv_hybrid_f,iadv_null,leq
+  use modfields,      only : u0,up,v0,vp,w0,wp,e120,e12p,thl0,thlp,qt0,qtp,sv0,svp
+  use modsubgrid,     only : lsmagorinsky
+  use advec_2nd,      only : advecu_2nd, advecv_2nd, advecw_2nd, advecc_2nd
+  use advec_52,       only : advecu_52, advecv_52, advecw_52, advecc_52
+  use advec_5th,      only : advecu_5th, advecv_5th, advecw_5th, advecc_5th
+  use advec_62,       only : advecu_62, advecv_62, advecw_62, advecc_62
+  use advec_6th,      only : advecu_6th, advecv_6th, advecw_6th, advecc_6th
+  use advec_hybrid,   only : advecc_hybrid
   use advec_hybrid_f, only : advecc_hybrid_f
+  use advec_kappa,    only : advecc_kappa
+  use advec_upw,      only : advecc_upw
   implicit none
   integer :: n
 
@@ -204,3 +213,4 @@ subroutine advection
   end do
 
 end subroutine advection
+end module modadvection

--- a/src/modbudget.f90
+++ b/src/modbudget.f90
@@ -213,6 +213,7 @@ contains
     use modfields,  only : u0,v0,w0,thv0h,u0av,v0av,rhobf,rhobh,thvh
 !cstep    use modtilt,    only : adjustbudget,ltilted
     use modmpi,     only : comm3d,my_real, mpi_sum,mpierr
+    use mpi
 
     implicit none
     integer :: i,j,k,km,kp,jm,jp
@@ -668,6 +669,7 @@ end subroutine do_genbudget
     use modsubgriddata, only : ekm,ekh,sbdiss,sbshr,sbbuo
     use modfields,  only : e120,rhobf
     use modmpi,     only : slabsum,comm3d,my_real, mpi_sum,mpierr
+    use mpi
     !----------------------------
     ! 1.1 Declare allocatable
     !----------------------------

--- a/src/modbulkmicro3.f90
+++ b/src/modbulkmicro3.f90
@@ -61,6 +61,7 @@ module modbulkmicro3
   subroutine initbulkmicro3
     use modglobal, only : lwarmstart,ifnamopt,fname_options,i1,ih,j1,jh,k1
     use modmpi,    only : myid,my_real,comm3d,mpi_logical
+    use mpi
     implicit none
     integer :: ierr
 

--- a/src/modbulkmicrostat.f90
+++ b/src/modbulkmicrostat.f90
@@ -260,6 +260,7 @@ subroutine initbulkmicrostat
     use modglobal,    only  : i1, j1, k1, ijtot
     use modmicrodata,  only  : qr,precep,Dvr,Nr,epscloud,epsqr,epsprec,imicro,imicro_bulk
     use modfields,  only  : ql0
+    use mpi
     implicit none
 
     integer :: k

--- a/src/modbulkmicrostat3.f90
+++ b/src/modbulkmicrostat3.f90
@@ -383,6 +383,7 @@ subroutine initbulkmicrostat3
     use modgenstat, only : ncid_prof=>ncid,nrec_prof=>nrec
     use modmicrodata3
     use modmpi,    only  : myid, my_real, comm3d, mpierr
+    use mpi
 
     implicit none
     integer  :: nsecs, nhrs, nminut

--- a/src/modfft2d.f90
+++ b/src/modfft2d.f90
@@ -38,6 +38,7 @@ contains
   subroutine fft2dinit(p, Fp, d, xyrt, ps,pe,qs,qe)
     use modmpi, only   : nprocx, nprocy
     use modglobal, only: itot, jtot, imax, jmax, kmax, i1, j1, ih, jh
+    use fftnew, only   : rffti
     implicit none
 
     real, pointer        :: p(:,:,:)
@@ -398,6 +399,7 @@ contains
 
     use modglobal, only : imax, jmax, kmax, itot, jtot, ijtot, i1, j1, ih, jh
     use modmpi, only    : myidx,myidy,nprocx
+    use fftnew, only    : rfftf
 
     implicit none
 
@@ -446,6 +448,7 @@ contains
 
     use modglobal, only : imax, jmax, kmax, itot, jtot, ijtot, i1, j1, ih, jh
     use modmpi, only    : myidx,myidy,nprocx
+    use fftnew, only    : rfftb
 
     implicit none
 

--- a/src/modfft2d.f90
+++ b/src/modfft2d.f90
@@ -23,6 +23,7 @@
 !  Copyright 2014 Netherlands eScience Center
 !
 module modfft2d
+use iso_fortran_env, only : int64
 
 implicit none
 
@@ -78,8 +79,8 @@ contains
 ! Prepare 1d FFT transforms
     allocate(winew(2*itot+15),wjnew(2*jtot+15))
 
-    CALL rffti(itot,winew)
-    CALL rffti(jtot,wjnew)
+    CALL rffti(int(itot,int64),winew)
+    CALL rffti(int(jtot,int64),wjnew)
 
     allocate(fptr(1:(imax+2*ih)*(jmax+2*jh)*kmax))
     allocate(   d(2-ih:i1+ih,2-jh:j1+jh,kmax))
@@ -416,14 +417,14 @@ contains
       call transpose_a(p, worka)
       do k=1,ke
       do j=1,jmax
-        call rfftf(itot,worka(1,j,k),winew)
+        call rfftf(int(itot,int64),worka(1,j,k),winew)
       enddo
       enddo
       call transpose_ainv(p, worka)
     else
       do k=1,kmax
       do j=2,j1
-        call rfftf(itot,p(2,j,k),winew)
+        call rfftf(int(itot,int64),p(2,j,k),winew)
       enddo
       enddo
     endif
@@ -435,7 +436,7 @@ contains
     call transpose_b(p, workb)
     do k=1,ke
     do i=1,imax
-      call rfftf(jtot,workb(1,i,k),wjnew)
+      call rfftf(int(jtot,int64),workb(1,i,k),wjnew)
     enddo
     enddo
     call transpose_binv(p, workb)
@@ -464,7 +465,7 @@ contains
     call transpose_b(p, workb)
     do k=1,ke
     do i=1,imax
-      call rfftb(jtot,workb(1,i,k),wjnew)
+      call rfftb(int(jtot,int64),workb(1,i,k),wjnew)
     enddo
     enddo
     call transpose_binv(p, workb)
@@ -477,14 +478,14 @@ contains
       call transpose_a(p, worka)
       do k=1,ke
       do j=1,jmax
-        call rfftb(itot,worka(1,j,k),winew)
+        call rfftb(int(itot,int64),worka(1,j,k),winew)
       enddo
       enddo
       call transpose_ainv(p, worka)
     else
       do k=1,kmax
       do j=2,j1
-        call rfftb(itot,p(2,j,k),winew)
+        call rfftb(int(itot,int64),p(2,j,k),winew)
       enddo
       enddo
     endif

--- a/src/modgenstat.f90
+++ b/src/modgenstat.f90
@@ -457,7 +457,7 @@ contains
   end subroutine genstat
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine do_genstat
-
+    use mpi
     use modfields, only : u0,v0,w0,um,vm,wm,qtm,thlm,thl0,qt0,qt0h, &
                           ql0,ql0h,thl0h,thv0h,sv0, svm, e12m,exnf,exnh
     use modsurfdata,only: thls,qts,svs,ustar,thlflux,qtflux,svflux
@@ -465,6 +465,7 @@ contains
     use modglobal, only : i1,ih,j1,jh,k1,kmax,nsv,dzf,dzh,rlv,rv,rd,cp, &
                           ijtot,cu,cv,iadv_sv,iadv_kappa,eps1,dxi,dyi
     use modmpi,    only : comm3d,my_real,mpi_sum,mpierr,slabsum
+    use advec_kappa, only : halflev_kappa
     implicit none
 
 

--- a/src/modheterostats.f90
+++ b/src/modheterostats.f90
@@ -266,6 +266,7 @@ contains
     use modsubgrid, only : ekm, ekh
     use modglobal,  only : iadv_sv, iadv_kappa, dzf, dzh, rlv, cp, rv, &
                            rd, imax, jmax, i1, j1, k1, ih, jh, itot
+    use advec_kappa,only : halflev_kappa
 
     implicit none
 

--- a/src/modquadrant.f90
+++ b/src/modquadrant.f90
@@ -555,6 +555,7 @@ contains
     use modfields, only : presh
     use modmpi,    only : myid,my_real,comm3d,mpierr,mpi_sum
     use modstat_nc, only: lnetcdf, writestat_nc,nc_fillvalue
+    use mpi
 
     implicit none
     real, allocatable, dimension(:,:)          :: vars

--- a/src/modsimpleicestat.f90
+++ b/src/modsimpleicestat.f90
@@ -246,6 +246,7 @@ subroutine initsimpleicestat
     use modglobal,    only  : i1, j1, k1, ijtot
     use modmicrodata,  only  : qr, precep, Nr, epscloud, epsqr, epsprec
     use modfields, only :ql0
+    use mpi
     implicit none
 
     integer :: k

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -302,6 +302,7 @@ contains
     use modglobal, only : itot,jtot, ysize,xsize,dtmax,runtime, startfile,lwarmstart,eps1, imax,jmax
     use modmpi,    only : myid,nprocx,nprocy,mpierr
     use modtimedep, only : ltimedep
+    use mpi
 
 
       if(mod(jtot,nprocy) /= 0) then
@@ -395,7 +396,7 @@ contains
 
     use modtestbed,        only : ltestbed,tb_ps,tb_thl,tb_qt,tb_u,tb_v,tb_w,tb_ug,tb_vg,&
                                   tb_dqtdxls,tb_dqtdyls,tb_qtadv,tb_thladv
-
+    use mpi
     integer i,j,k,n
     logical negval !switch to allow or not negative values in randomnization
 
@@ -1208,6 +1209,7 @@ contains
     use modglobal,         only : k1,kmax,zf,zh,dzf,dzh,rv,rd,grav,cp,pref0,lwarmstart,ibas_prf,cexpnr,ifinput,ifoutput
     use modsurfdata,       only : thls,ps,qts
     use modmpi,            only : myid,comm3d,mpierr,my_real
+    use mpi
     implicit none
 
     real :: thvb,prsb ! for calculating moist adiabat

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -668,6 +668,7 @@ contains
     use modglobal, only : i1,j1,k1,dzf,dzh,iadv_thl, iadv_qt, iadv_kappa
     use modfields, only : thl0,thl0h,qt0,qt0h
     use modsurfdata,only: qts,thls
+    use advec_kappa,only: halflev_kappa
     implicit none
 
     integer :: i,j,k

--- a/src/modtimestat.f90
+++ b/src/modtimestat.f90
@@ -942,6 +942,7 @@ contains
     use modsurface, only : patchxnr,patchynr
     use mpi
     use modmpi,     only : mpierr, comm3d,mpi_sum,my_real
+    use advec_kappa,only : halflev_kappa
     implicit none
     real    :: zil, dhdt,locval,oldlocval
     integer :: location,i,j,k,nsamp,stride

--- a/src/program.f90
+++ b/src/program.f90
@@ -150,6 +150,7 @@ program DALES
   !use modprojection,   only : initprojection, projection
   use modchem,         only : initchem,twostep
   use modcanopy,       only : initcanopy, canopy, exitcanopy
+  use modadvection,    only : advection
 
 
   implicit none

--- a/src/rrtmg_lw_init.f90
+++ b/src/rrtmg_lw_init.f90
@@ -20,22 +20,22 @@
       use modglobal, only: im => kind_im, rb => kind_rb
       use rrlw_wvn
       use rrtmg_lw_setcoef, only: lwatmref, lwavplank
-!      use rrlw_kgb01                  ! molecular absorption coefficients
-!      use rrlw_kgb02
-!      use rrlw_kgb03
-!      use rrlw_kgb04
-!      use rrlw_kgb05
-!      use rrlw_kgb06
-!      use rrlw_kgb07
-!      use rrlw_kgb08
-!      use rrlw_kgb09
-!      use rrlw_kgb10
-!      use rrlw_kgb11
-!      use rrlw_kgb12
-!      use rrlw_kgb13
-!      use rrlw_kgb14
-!      use rrlw_kgb15
-!      use rrlw_kgb16
+      use rrtmg_lw_read_nc, only: lw_kgb01 & ! molecular absorption coefficients
+                                , lw_kgb02 &
+                                , lw_kgb03 &
+                                , lw_kgb04 &
+                                , lw_kgb05 &
+                                , lw_kgb06 &
+                                , lw_kgb07 &
+                                , lw_kgb08 &
+                                , lw_kgb09 &
+                                , lw_kgb10 &
+                                , lw_kgb11 &
+                                , lw_kgb12 &
+                                , lw_kgb13 &
+                                , lw_kgb14 &
+                                , lw_kgb15 &
+                                , lw_kgb16 
 
       implicit none
 

--- a/src/rrtmg_lw_read_nc.f90
+++ b/src/rrtmg_lw_read_nc.f90
@@ -15,6 +15,8 @@
 ! Last Update: 1/23/2009
 !===============================================================================
 
+module rrtmg_lw_read_nc
+contains
 !*******************************************************************************
 subroutine lw_kgb01
     use rrlw_kg01, only : fracrefao, fracrefbo, kao, kbo, kao_mn2, kbo_mn2, &
@@ -1030,3 +1032,4 @@ subroutine lw_kgb16
 
 end subroutine lw_kgb16
 !*******************************************************************************
+end module rrtmg_lw_read_nc

--- a/src/rrtmg_sw_init.f90
+++ b/src/rrtmg_sw_init.f90
@@ -41,6 +41,20 @@
       use parrrsw, only : mg, nbndsw, ngptsw
       use rrsw_tbl, only: ntbl, tblint, pade, bpade, tau_tbl, exp_tbl
       use rrsw_vsn, only: hvrini, hnamini
+      use rrtmg_sw_read_nc, only : sw_kgb16 & ! molecular absorption coefficients
+                                 , sw_kgb17 &
+                                 , sw_kgb18 &
+                                 , sw_kgb19 &
+                                 , sw_kgb20 &
+                                 , sw_kgb21 &
+                                 , sw_kgb22 &
+                                 , sw_kgb23 &
+                                 , sw_kgb24 &
+                                 , sw_kgb25 &
+                                 , sw_kgb26 &
+                                 , sw_kgb27 &
+                                 , sw_kgb28 &
+                                 , sw_kgb29 
 
       real(kind=rb), intent(in) :: cpdair     ! Specific heat capacity of dry air
                                               ! at constant pressure at 273 K

--- a/src/rrtmg_sw_read_nc.f90
+++ b/src/rrtmg_sw_read_nc.f90
@@ -14,6 +14,8 @@
 ! Last Update: 4/3/2009
 !===============================================================================
 
+module rrtmg_sw_read_nc
+contains
 !*******************************************************************************
 subroutine sw_kgb16
     use rrsw_kg16, only: sfluxrefo, kao, kbo, selfrefo, forrefo, rayl, no16
@@ -794,3 +796,4 @@ subroutine sw_kgb29
 
 end subroutine sw_kgb29
 !*******************************************************************************
+end module rrtmg_sw_read_nc


### PR DESCRIPTION
- Creating explicit interfaces allows compilation without ``std=legacy`` and with ``-Werror=implicit-interface -std=gnu``
- Implicit conversion errors between subroutines are caught at compile time