### PR TITLE
Fix Intel build in CI/CD pipeline

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -71,17 +71,6 @@ jobs:
           sudo ln -s `which ifx` /usr/bin/ifx
           cd netcdf-fortran
           NCDIR=/usr FC=/usr/bin/ifx ./configure
-          echo "Check path:"
-          ls /opt/intel/oneapi/compiler/latest/lib
-          #fix weird bug where libmf et al are not found
-          #sudo cp /opt/intel/oneapi/compiler/latest/lib/libimf.so \
-           #  /opt/intel/oneapi/compiler/latest/linux/lib/
-          #sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libintlc.so.5 \
-          #   /opt/intel/oneapi/compiler/latest/linux/lib/
-          #sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libsvml.so \
-          #   /opt/intel/oneapi/compiler/latest/linux/lib/
-          #sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libirng.so \
-          #   /opt/intel/oneapi/compiler/latest/linux/lib/
           sudo make -j2
           sudo make install
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -71,6 +71,8 @@ jobs:
           sudo ln -s `which ifx` /usr/bin/ifx
           cd netcdf-fortran
           NCDIR=/usr FC=/usr/bin/ifx ./configure
+          echo "Check path:"
+          ls /opt/intel/oneapi/compiler/latest/linux/compiler/lib
           #fix weird bug where libmf et al are not found
           sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libimf.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -72,7 +72,7 @@ jobs:
           cd netcdf-fortran
           NCDIR=/usr FC=/usr/bin/ifx ./configure
           echo "Check path:"
-          ls /opt/intel/oneapi/compiler/latest/linux/compiler/lib
+          ls /opt/intel/oneapi/compiler
           #fix weird bug where libmf et al are not found
           sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libimf.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -72,7 +72,7 @@ jobs:
           cd netcdf-fortran
           NCDIR=/usr FC=/usr/bin/ifx ./configure
           echo "Check path:"
-          ls /opt/intel/oneapi/compiler/latest
+          ls /opt/intel/oneapi/compiler/latest/lib
           #fix weird bug where libmf et al are not found
           sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libimf.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -67,10 +67,10 @@ jobs:
         if: matrix.toolchain == 'intel'
         run: |
           source /opt/intel/oneapi/setvars.sh
-          #make sure ifort is found
-          sudo ln -s `which ifort` /usr/bin/ifort
+          #make sure ifx is found
+          sudo ln -s `which ifx` /usr/bin/ifx
           cd netcdf-fortran
-          NCDIR=/usr FC=/usr/bin/ifort ./configure
+          NCDIR=/usr FC=/usr/bin/ifx ./configure
           #fix weird bug where libmf et al are not found
           sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64/libimf.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -74,14 +74,14 @@ jobs:
           echo "Check path:"
           ls /opt/intel/oneapi/compiler/latest/lib
           #fix weird bug where libmf et al are not found
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libimf.so \
-             /opt/intel/oneapi/compiler/latest/linux/lib/
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libintlc.so.5 \
-             /opt/intel/oneapi/compiler/latest/linux/lib/
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libsvml.so \
-             /opt/intel/oneapi/compiler/latest/linux/lib/
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libirng.so \
-             /opt/intel/oneapi/compiler/latest/linux/lib/
+          #sudo cp /opt/intel/oneapi/compiler/latest/lib/libimf.so \
+           #  /opt/intel/oneapi/compiler/latest/linux/lib/
+          #sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libintlc.so.5 \
+          #   /opt/intel/oneapi/compiler/latest/linux/lib/
+          #sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libsvml.so \
+          #   /opt/intel/oneapi/compiler/latest/linux/lib/
+          #sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libirng.so \
+          #   /opt/intel/oneapi/compiler/latest/linux/lib/
           sudo make -j2
           sudo make install
 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -72,7 +72,7 @@ jobs:
           cd netcdf-fortran
           NCDIR=/usr FC=/usr/bin/ifx ./configure
           echo "Check path:"
-          ls /opt/intel/oneapi/compiler
+          ls /opt/intel/oneapi/compiler/latest
           #fix weird bug where libmf et al are not found
           sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libimf.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -72,13 +72,13 @@ jobs:
           cd netcdf-fortran
           NCDIR=/usr FC=/usr/bin/ifx ./configure
           #fix weird bug where libmf et al are not found
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64/libimf.so \
+          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libimf.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64/libintlc.so.5 \
+          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libintlc.so.5 \
              /opt/intel/oneapi/compiler/latest/linux/lib/
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64/libsvml.so \
+          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libsvml.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/
-          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64/libirng.so \
+          sudo cp /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libirng.so \
              /opt/intel/oneapi/compiler/latest/linux/lib/
           sudo make -j2
           sudo make install


### PR DESCRIPTION
Intel released a new version of the oneAPI toolkit (version 2024) and this broke the builds in the Intel CI/CD pipelines. Fixed by removing the manual copies of `libimf`, `libintlc`, `libsvml` and `libirng`. 

I also changed the compiler for NetCDF from `ifort` to the newer `ifx`, since `ifort` [is set to be discontinued in 2024](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-hpc-toolkit-release-notes.html). 