### PR TITLE
fftw fixes

### DIFF
--- a/src/modfftw.f90
+++ b/src/modfftw.f90
@@ -779,16 +779,16 @@ contains
   subroutine D_fftw_execute_r2r(p, in, out)
       implicit none
       type(C_PTR) :: p
-      real(C_DOUBLE), pointer, contiguous, intent(inout) :: in(:)
-      real(C_DOUBLE), pointer, contiguous, intent(out)   :: out(:)
+      real(C_DOUBLE), pointer, contiguous :: in(:)
+      real(C_DOUBLE), pointer, contiguous :: out(:)
       call fftw_execute_r2r(p, in, out)
   end subroutine
 
   subroutine D_fftwf_execute_r2r(p, in, out)
       implicit none
       type(C_PTR) :: p
-      real(C_FLOAT), pointer, contiguous, intent(inout) :: in(:)
-      real(C_FLOAT), pointer, contiguous, intent(out)   :: out(:)
+      real(C_FLOAT), pointer, contiguous :: in(:)
+      real(C_FLOAT), pointer, contiguous :: out(:)
       call fftwf_execute_r2r(p, in, out)
   end subroutine
 
@@ -797,11 +797,11 @@ contains
       integer(C_INT) :: rank
       integer(C_INT), intent(in) :: n(:)
       integer(C_INT) :: howmany
-      real(C_DOUBLE), pointer, intent(out) :: in(:)
+      real(C_DOUBLE), pointer :: in(:)
       integer(C_INT), intent(in) :: inembed(:)
       integer(C_INT) :: istride
       integer(C_INT) :: idist
-      real(C_DOUBLE), pointer, intent(out) :: out(:)
+      real(C_DOUBLE), pointer :: out(:)
       integer(C_INT), intent(in) :: onembed(:)
       integer(C_INT) :: ostride
       integer(C_INT) :: odist
@@ -816,11 +816,11 @@ contains
       integer(C_INT) :: rank
       integer(C_INT), intent(in) :: n(:)
       integer(C_INT) :: howmany
-      real(C_FLOAT), pointer, intent(out) :: in(:)
+      real(C_FLOAT), pointer :: in(:)
       integer(C_INT), intent(in) :: inembed(:)
       integer(C_INT) :: istride
       integer(C_INT) :: idist
-      real(C_FLOAT), pointer, intent(out) :: out(:)
+      real(C_FLOAT), pointer :: out(:)
       integer(C_INT), intent(in) :: onembed(:)
       integer(C_INT) :: ostride
       integer(C_INT) :: odist
@@ -835,8 +835,8 @@ contains
       type(fftw_iodim), intent(in) :: dims(:)
       integer(C_INT) :: howmany_rank
       type(fftw_iodim), intent(in) :: howmany_dims(:)
-      real(C_DOUBLE), intent(out) :: in(:)
-      real(C_DOUBLE), intent(out) :: out(:)
+      real(C_DOUBLE) :: in(:)
+      real(C_DOUBLE) :: out(:)
       integer(C_FFTW_R2R_KIND), intent(in) :: kind(:)
       integer(C_INT) :: flags
       d_fftw_plan_guru_r2r = fftw_plan_guru_r2r(rank,dims,howmany_rank,howmany_dims,in,out,kind,flags)
@@ -847,8 +847,8 @@ contains
       type(fftw_iodim), intent(in) :: dims(:)
       integer(C_INT) :: howmany_rank
       type(fftw_iodim), intent(in) :: howmany_dims(:)
-      real(C_FLOAT), intent(out) :: in(:)
-      real(C_FLOAT), intent(out) :: out(:)
+      real(C_FLOAT) :: in(:)
+      real(C_FLOAT) :: out(:)
       integer(C_FFTW_R2R_KIND), intent(in) :: kind(:)
       integer(C_INT) :: flags
 

--- a/src/modfftw.f90
+++ b/src/modfftw.f90
@@ -162,8 +162,15 @@ contains
               iony*jonx*kmax                    ) ! Fp (p102)
 
     ! get aligned memory for FFTW
+#if POIS_PRECISION == 64
     ptr = fftw_alloc_real(sz)
-
+#else
+    ptr = fftwf_alloc_real(sz)
+#endif
+    if( .not. c_associated(ptr) ) then
+       write (*,*) "modfftw: ptr is not associated,  fftw(f)_alloc_real(", sz, ") failed."
+       stop "fftw(f)_alloc_real failed"
+    end if
     ! convert it to a fortran pointer, or 1D array
     call c_f_pointer(ptr, fptr, (/sz/))
 


### PR DESCRIPTION
Fixes for running on Fugaku:
intent on pointers in FFTW interface - tripped debug build on Fugaku
fix zeroing of unused parts of p201 - was still wrong when more than one tile has fewer elements
call fftw(f)_alloc_real depending on POIS_PRECISION - save memory by calling the correct fftw allocate.
