### PR TITLE
Fixes for running with open boundary conditions over land

### DIFF
--- a/src/advec_2nd.f90
+++ b/src/advec_2nd.f90
@@ -255,7 +255,7 @@ subroutine advecv_2nd(a_in, a_out, sy)
 
     !$acc parallel loop collapse(3) default(present) async(2)
     do k = 2, kmax
-      do j = 2, j1
+      do j = sy, j1
         do i = 2, i1
           a_out(i,j,k)  = a_out(i,j,k)- (1/rhobf(k))*( &
             (w0(i,j,k+1)+w0(i,j-1,k+1)) &

--- a/src/modbulkmicro.f90
+++ b/src/modbulkmicro.f90
@@ -200,7 +200,7 @@ module modbulkmicro
 
 !> Calculates the microphysical source term.
   subroutine bulkmicro
-    use modglobal, only : i1,j1,k1,rdt,rk3step,timee,rlv,cp
+    use modglobal, only : i1,j1,kmax,k1,rdt,rk3step,timee,rlv,cp
     use modfields, only : sv0,svm,svp,qtp,thlp,ql0,exnf,rhof
     use modbulkmicrostat, only : bulkmicrotend
     use modmpi,    only : myid
@@ -321,16 +321,16 @@ module modbulkmicro
     qrmask = qr.gt.qrmin.and.Nr.gt.0
     qrbase = k1 + 1
     qrroof = 1 - 1
-    do k=1,k1
+    do k=1,kmax
       if (any(qrmask(:,:,k))) then
         qrbase = max(1, k)
         exit
       endif
     enddo
     if (qrbase.le.k1) then
-      do k=k1,qrbase,-1
+      do k=kmax,qrbase,-1
         if (any(qrmask(:,:,k))) then
-          qrroof = min(k1, k)
+          qrroof = min(kmax, k)
           exit
         endif
       enddo
@@ -339,16 +339,16 @@ module modbulkmicro
     qcmask = ql0(2:i1,2:j1,1:k1).gt.qcmin
     qcbase = k1 + 1
     qcroof = 1 - 1
-    do k=1,k1
+    do k=1,kmax
       if (any(qcmask(:,:,k))) then
         qcbase = max(1, k)
         exit
       endif
     enddo
     if (qcbase.le.k1) then
-      do k=k1,qcbase,-1
+      do k=kmax,qcbase,-1
         if (any(qcmask(:,:,k))) then
-          qcroof = min(k1, k)
+          qcroof = min(kmax, k)
           exit
         endif
       enddo

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -159,8 +159,8 @@ contains
     
     !$acc parallel loop collapse(3) default(present) async(1)
     do k = 1, kmax
-      do j = 2, j1
-        do i = sx, i1
+      do j = sy, j1
+        do i = 2, i1
           vp(i,j,k) = vp(i,j,k)  - cu*om23 &
                 -(u0(i,j,k)+u0(i,j-1,k)+u0(i+1,j-1,k)+u0(i+1,j,k))*om23*0.25_field_r
         end do

--- a/src/modgenstat.f90
+++ b/src/modgenstat.f90
@@ -540,7 +540,7 @@ contains
     use modsurfdata,only: thls,qts,svs,ustar,thlflux,qtflux,svflux
     use modsubgriddata,only : ekm, ekh, csz
     use modglobal, only : i1,ih,j1,jh,k1,kmax,nsv,dzf,dzh,rlv,rv,rd,cp,dzhi, &
-                          ijtot,cu,cv,iadv_sv,iadv_kappa,eps1,dxi,dyi,tup,tdn
+                          ijtot,cu,cv,iadv_sv,iadv_kappa,eps1,dxi,dyi,tup,tdn,lopenbc
     use modmpi,    only : comm3d,mpi_sum,mpierr,slabsum,D_MPI_ALLREDUCE,myid
     use advec_kappa, only : halflev_kappa
     use modmicrodata, only: tuprsg, tdnrsg, imicro, imicro_sice, imicro_sice2, iqr
@@ -889,7 +889,7 @@ contains
       end do
 
       do n = 1, nsv
-        if (iadv_sv(n)==iadv_kappa) then
+        if (iadv_sv(n)==iadv_kappa .and. .not. lopenbc) then
            call halflev_kappa(sv0(:,:,:,n),sv0h)
         else
           !$acc parallel loop collapse(3) default(present) async(1)

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -814,7 +814,7 @@ implicit none
 integer errcode
 
 write(6,*) 'Error: ', nf90_strerror(errcode)
-stop 2
+call abort
 end subroutine handle_err
 
 end module modglobal

--- a/src/modlsm.f90
+++ b/src/modlsm.f90
@@ -2358,7 +2358,7 @@ subroutine check(status)
     integer, intent (in) :: status
     if(status /= nf90_noerr) then
         print *,'NetCDF error: ', trim(nf90_strerror(status))
-        stop
+        call abort
     end if
 end subroutine check
 

--- a/src/modlsmcrosssection.f90
+++ b/src/modlsmcrosssection.f90
@@ -65,7 +65,7 @@ save
 contains
 !> Initializing lsmcrosssection. Read out the namelist, initializing the variables
   subroutine initlsmcrosssection
-    use modmpi,      only : myid,mpierr,comm3d,cmyid,D_MPI_BCAST
+    use modmpi,      only : myid,myidy,mpierr,comm3d,cmyid,D_MPI_BCAST
     use modglobal,   only : imax,jmax,ifnamopt,fname_options,dtmax,dtav_glob,ladaptive,j1,dt_lim,cexpnr,tres,btime,checknamelisterror,&
                             output_prefix
     use modstat_nc,  only : lnetcdf,open_nc, define_nc,ncinfo,nctiminfo,writestat_dims_nc
@@ -113,7 +113,7 @@ contains
       stop 'lsmcrosssection: dtav should be a integer multiple of dtmax'
     end if
     if (lnetcdf) then
-      if (myid==0) then
+      if (myidy==0) then
         fname1(12:19) = cmyid
         fname1(21:23) = cexpnr
         call nctiminfo(tncname1(1,:))
@@ -229,7 +229,7 @@ contains
   subroutine wrtvert
   use modglobal, only : imax,i1,cexpnr,ifoutput,rtimee
   use modsurfdata, only : tsoil, phiw
-  use modmpi,    only : myid
+  use modmpi,    only : myidy
   use modstat_nc, only : lnetcdf, writestat_nc
   implicit none
 
@@ -237,7 +237,7 @@ contains
 
   real, allocatable :: vars(:,:,:)
 
-  if( myid /= 0 ) return
+  if( myidy /= 0 ) return
 
     open(ifoutput,file='movv_tsoil.'//cexpnr,position='append',action='write')
     write(ifoutput,'(es12.5)') ((tsoil(i,crossplane,k),i=2,i1),k=1,ksoilmax)
@@ -396,11 +396,11 @@ contains
 !> Clean up when leaving the run
   subroutine exitlsmcrosssection
     use modstat_nc, only : exitstat_nc,lnetcdf
-    use modmpi, only : myid
+    use modmpi, only : myidy
     implicit none
 
     if(lcross .and. lnetcdf) then
-      if (myid==0) then
+      if (myidy==0) then
         call exitstat_nc(ncid1)
       end if
       call exitstat_nc(ncid2)

--- a/src/modopenboundary.f90
+++ b/src/modopenboundary.f90
@@ -1202,7 +1202,7 @@ contains
   integer errcode
 
   write(6,*) 'Error: ', nf90_strerror(errcode)
-  stop 2
+  call abort
 
   end subroutine handle_err
 

--- a/src/modopenboundary.f90
+++ b/src/modopenboundary.f90
@@ -63,11 +63,11 @@ contains
     if(.not.lopenbc) return
     ! Check for conflicting options
     if(solver_id == 0) stop 'Openboundaries only possible with HYPRE or FFTW pressure solver, change solver_id'
-    if(iadv_mom /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_mom to 2'
-    if(iadv_thl /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_thl to 2'
-    if(iadv_qt  /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_qt to 2'
-    if(iadv_tke /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_tke to 2'
-    if(any(iadv_sv(1:nsv)/=2)) stop 'Only second order advection scheme supported with openboundaries, change iadv_sv to 2'
+    !if(iadv_mom /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_mom to 2'
+    !if(iadv_thl /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_thl to 2'
+    !if(iadv_qt  /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_qt to 2'
+    !if(iadv_tke /=2) stop 'Only second order advection scheme supported with openboundaries, change iadv_tke to 2'
+    !if(any(iadv_sv(1:nsv)/=2)) stop 'Only second order advection scheme supported with openboundaries, change iadv_sv to 2'
     if(cu/=0.) stop 'Translation velocity not allowed in combination with open boundaries, set cu to 0'
     if(cv/=0.) stop 'Translation velocity not allowed in combination with open boundaries, set cv to 0'
     ! Set buoyancy term at top boundary on or off (off default)
@@ -794,15 +794,15 @@ contains
         do j = 1,nx1
           un = u0(sx,min(j+1,j1),min(k,kmax))
           if(un<=0) then ! Homogeneous Neumann outflow
-            a(sx-1,j+1,k)=a(sx,j+1,k)
+            a(2-ih:sx-1,j+1,k)=a(sx,j+1,k)
           else ! Robin inflow conditions
             e = e120(sx,min(j+1,j1),min(k,kmax))
             coefdir = abs(un)**pbc
             coefneu = -tauh*un*(abs(un)**pbc+e**pbc)
             valtarget = (fp*val(j,k,itp)+fm*val(j,k,itm)+turb(j,k))*coefdir
-            a(sx-1,j+1,k) = ( 2.*dx*valtarget - &
+            a(2-ih:sx-1,j+1,k) = ( 2.*dx*valtarget - &
               a(sx,j+1,k)*(coefdir*dx+2.*coefneu) ) / (coefdir*dx-2.*coefneu)
-            if(lmax0==1) a(sx-1,j+1,k) = max(0._field_r,a(sx-1,j+1,k))
+            if(lmax0==1) a(sx-1,j+1,k) = max(0.,a(sx-1,j+1,k))
           endif
         end do
       end do
@@ -811,15 +811,15 @@ contains
         do j = 1,nx1
           un = u0(ex+1,min(j+1,j1),min(k,kmax))
           if(un>=0) then ! Homogeneous Neumann outflow
-            a(ex+1,j+1,k)=a(ex,j+1,k)
+            a(ex+1:i1+ih,j+1,k)=a(ex,j+1,k)
           else ! Robin inflow conditions
             e = e120(ex,min(j+1,j1),min(k,kmax))
             coefdir = abs(un)**pbc
             coefneu = -tauh*un*(abs(un)**pbc+e**pbc)
             valtarget = (fp*val(j,k,itp)+fm*val(j,k,itm)+turb(j,k))*coefdir
-            a(ex+1,j+1,k) = ( 2.*dx*valtarget - &
+            a(ex+1:i1+ih,j+1,k) = ( 2.*dx*valtarget - &
               a(ex,j+1,k)*(coefdir*dx-2.*coefneu) ) / (coefdir*dx+2.*coefneu)
-            if(lmax0==1) a(ex+1,j+1,k) = max(a(ex+1,j+1,k),0._field_r)
+            if(lmax0==1) a(ex+1,j+1,k) = max(a(ex+1,j+1,k),0.)
           endif
         end do
       end do
@@ -828,15 +828,15 @@ contains
         do i = 1,nx1
           un = v0(min(i+1,i1),sy,min(k,kmax))
           if(un<=0) then ! Homogeneous Neumann outflow
-            a(i+1,sy-1,k)=a(i+1,sy,k)
+            a(i+1,2-jh:sy-1,k)=a(i+1,sy,k)
           else ! Robin inflow conditions
             e = e120(min(i+1,i1),sy,min(k,kmax))
             coefdir = abs(un)**pbc
             coefneu = -tauh*un*(abs(un)**pbc+e**pbc)
             valtarget = (fp*val(i,k,itp)+fm*val(i,k,itm)+turb(i,k))*coefdir
-            a(i+1,sy-1,k) = ( 2.*dy*valtarget - &
+            a(i+1,2-jh:sy-1,k) = ( 2.*dy*valtarget - &
               a(i+1,sy,k)*(coefdir*dy+2.*coefneu) ) / (coefdir*dy-2.*coefneu)
-            if(lmax0==1) a(i+1,sy-1,k) = max(a(i+1,sy-1,k),0._field_r)
+            if(lmax0==1) a(i+1,sy-1,k) = max(a(i+1,sy-1,k),0.)
           endif
         end do
       end do
@@ -845,15 +845,15 @@ contains
         do i = 1,nx1
           un = v0(min(i+1,i1),ey+1,min(k,kmax))
           if(un>=0) then ! Homogeneous Neumann outflow
-            a(i+1,ey+1,k)=a(i+1,ey,k)
+            a(i+1,ey+1:j1+ih,k)=a(i+1,ey,k)
           else ! Robin inflow conditions
             e = e120(min(i+1,i1),ey,min(k,kmax))
             coefdir = abs(un)**pbc
             coefneu = -tauh*un*(abs(un)**pbc+e**pbc)
             valtarget = (fp*val(i,k,itp)+fm*val(i,k,itm)+turb(i,k))*coefdir
-            a(i+1,ey+1,k) = ( 2.*dy*valtarget - &
+            a(i+1,ey+1:j1+jh,k) = ( 2.*dy*valtarget - &
               a(i+1,ey,k)*(coefdir*dy-2.*coefneu) ) / (coefdir*dy+2.*coefneu)
-            if(lmax0==1) a(i+1,ey+1,k) = max(a(i+1,ey+1,k),0._field_r)
+            if(lmax0==1) a(i+1,ey+1,k) = max(a(i+1,ey+1,k),0.)
           endif
         end do
       end do
@@ -877,7 +877,7 @@ contains
             valtarget = (fp*val(i,j,itp)+fm*val(i,j,itm)+turb(i,j))*coefdir+ddz*coefneu
             a(i+1,j+1,ez) = ( 2.*dzh(ez)*valtarget - &
               a(i+1,j+1,ez-1)*(coefdir*dzh(ez)-2.*coefneu) ) / (coefdir*dzh(ez)+2.*coefneu)
-            if(lmax0==1) a(i+1,j+1,ez) = max(a(i+1,j+1,ez),0._field_r)
+            if(lmax0==1) a(i+1,j+1,ez) = max(a(i+1,j+1,ez),0.)
           endif
         end do
       end do
@@ -888,14 +888,15 @@ contains
     ! Subroutine that applies the radiation and dirichlet boundary conditions
     ! for the boundary-normal velocity components. Adds turbulence to
     ! the inflow dirichlet boundaries if lsynturb=.true.
+
     use modmpi, only : myidx,myidy,myid
-    use modglobal, only : dx,dy,dzf,dxi,dyi,rdt,i2,j2,k1,i1,j1,kmax,rtimee,rdt,itot,jtot,imax,jmax,grav,taum
+    use modglobal, only : dx,dy,dzf,dxi,dyi,rdt,i2,j2,k1,i1,j1,kmax,ih,jh,rtimee,rdt,itot,jtot,imax,jmax,grav,taum
     use modfields, only : um,u0,up,vm,v0,vp,wm,w0,wp,rhobf,rhobh,thvh,thv0h
     implicit none
     integer, intent(in) :: nx1,nx2,ib
     real(field_r), intent(in), dimension(nx1,nx2) :: turb
     integer :: i,j,k,itmc,itmn,itpc,itpn,ipatch,jpatch,kpatch
-    real(field_r) :: tm,tp,fpc,fmc,fpn,fmn,unext,uwallcurrent,ipos,jpos,tau
+    real :: tm,tp,fpc,fmc,fpn,fmn,unext,uwallcurrent,ipos,jpos,tau
     itmc=1
     itmn=1
     if(ntboundary>1) then
@@ -940,11 +941,11 @@ contains
           kpatch = k
           uwallcurrent = fpc*boundary(1)%u(j,k,itpc)+fmc*boundary(1)%u(j,k,itmc)
           if(uwallcurrent<=0.) then ! Outflow (Radiation)
-            up(2,j+1,k) = -max(min(boundary(1)%uphase(jpatch,kpatch),uwallcurrent),-dx/rdt) * &
+            up(2-ih:2,j+1,k) = -max(min(boundary(1)%uphase(jpatch,kpatch),uwallcurrent),-dx/rdt) * &
               (u0(3,j+1,k)-u0(2,j+1,k))*dxi
           else ! Inflow nudging
             unext = fpn*boundary(1)%u(j,k,itpn)+fmn*boundary(1)%u(j,k,itmn)
-            up(2,j+1,k) = ((unext+turb(j,k)) - u0(2,j+1,k))/tau
+            up(2-ih:2,j+1,k) = ((unext+turb(j,k)) - u0(2,j+1,k))/tau
           endif
         end do
       end do
@@ -957,11 +958,11 @@ contains
           kpatch = k
           uwallcurrent = fpc*boundary(2)%u(j,k,itpc)+fmc*boundary(2)%u(j,k,itmc)
           if(uwallcurrent>=0.) then ! Outflow (Radiation)
-            up(i2,j+1,k) = -min(max(boundary(2)%uphase(jpatch,kpatch),uwallcurrent),dx/rdt) * &
+            up(i2:i1+ih,j+1,k) = -min(max(boundary(2)%uphase(jpatch,kpatch),uwallcurrent),dx/rdt) * &
               (u0(i2,j+1,k)-u0(i1,j+1,k))*dxi
           else ! Inflow (Dirichlet)
             unext = fpn*boundary(2)%u(j,k,itpn)+fmn*boundary(2)%u(j,k,itmn)
-            up(i2,j+1,k) = ((unext+turb(j,k)) - u0(i2,j+1,k))/tau
+            up(i2:i1+ih,j+1,k) = ((unext+turb(j,k)) - u0(i2,j+1,k))/tau
           endif
         end do
       end do
@@ -974,11 +975,11 @@ contains
           kpatch = k
           uwallcurrent = fpc*boundary(3)%v(i,k,itpc)+fmc*boundary(3)%v(i,k,itmc)
           if(uwallcurrent<=0.) then ! Outflow (Radiation)
-            vp(i+1,2,k) = -max(min(boundary(3)%uphase(ipatch,kpatch),uwallcurrent),-dy/rdt) * &
+            vp(i+1,2-jh:2,k) = -max(min(boundary(3)%uphase(ipatch,kpatch),uwallcurrent),-dy/rdt) * &
               (v0(i+1,3,k)-v0(i+1,2,k))*dyi
           else ! Inflow (Dirichlet)
             unext = fpn*boundary(3)%v(i,k,itpn)+fmn*boundary(3)%v(i,k,itmn)
-            vp(i+1,2,k) = ((unext+turb(i,k)) - v0(i+1,2,k))/tau
+            vp(i+1,2-jh:2,k) = ((unext+turb(i,k)) - v0(i+1,2,k))/tau
           endif
         end do
       end do
@@ -991,11 +992,11 @@ contains
           kpatch = k
           uwallcurrent = fpc*boundary(4)%v(i,k,itpc)+fmc*boundary(4)%v(i,k,itmc)
           if(uwallcurrent>=0.) then ! Outflow (Radiation)
-            vp(i+1,j2,k) = -min(max(boundary(4)%uphase(ipatch,kpatch),uwallcurrent),dy/rdt) * &
+            vp(i+1,j2:j1+jh,k) = -min(max(boundary(4)%uphase(ipatch,kpatch),uwallcurrent),dy/rdt) * &
               (v0(i+1,j2,k)-v0(i+1,j1,k))*dyi
           else ! Inflow (Dirichlet)
             unext = fpn*boundary(4)%v(i,k,itpn)+fmn*boundary(4)%v(i,k,itmn)
-            vp(i+1,j2,k) = ((unext+turb(i,k)) - v0(i+1,j2,k))/tau
+            vp(i+1,j2:j1+jh,k) = ((unext+turb(i,k)) - v0(i+1,j2,k))/tau
           endif
         end do
       end do

--- a/src/modsynturb.f90
+++ b/src/modsynturb.f90
@@ -200,7 +200,7 @@ contains
   integer errcode
 
   write(6,*) 'Error: ', nf90_strerror(errcode)
-  stop 2
+  call abort
 
   end subroutine handle_err
 

--- a/src/modtestbed.f90
+++ b/src/modtestbed.f90
@@ -785,7 +785,7 @@ contains
   integer errcode
      
   write(6,*) 'Error: ', nf90_strerror(errcode)
-  stop 2
+  call abort
       
   end subroutine handle_err
 

--- a/src/tstep.f90
+++ b/src/tstep.f90
@@ -180,7 +180,7 @@ subroutine tstep_update
   !$acc parallel loop collapse(3) default(present) async(1)
   do k = 1, k1
     do j = 2, j2     ! i2, j2 here to include one ghost cell,
-      do i = 1, i2   ! needed for up, vp with open boundaries
+      do i = 2, i2   ! needed for up, vp with open boundaries
         up(i,j,k)=0.
         vp(i,j,k)=0.
         wp(i,j,k)=0.
@@ -197,7 +197,7 @@ subroutine tstep_update
     do n = 1, nsv
       do k = 1, k1
         do j = 2, j1
-          do i = 1, i1
+          do i = 2, i1
             svp(i,j,k,n)=0.
           enddo
         enddo

--- a/src/tstep.f90
+++ b/src/tstep.f90
@@ -64,7 +64,7 @@ subroutine exittstep
 end subroutine exittstep
 
 subroutine tstep_update
-  use modglobal, only : i1,j1,k1,rk3step,timee,rtimee,dtmax,dt,ntrun,courant,peclet,dt_reason,nsv, &
+  use modglobal, only : i1,j1,k1,i2,j2,rk3step,timee,rtimee,dtmax,dt,ntrun,courant,peclet,dt_reason,nsv, &
                         kmax,dx,dy,dzh,dt_lim,ladaptive,timeleft,idtmax,rdt,tres,longint ,lwarmstart
   use modfields, only : um,vm,wm,up,vp,wp,thlp,svp,qtp,e12p
   use modsubgrid,only : ekm,ekh
@@ -179,8 +179,8 @@ subroutine tstep_update
   ! set all tendencies to zero
   !$acc parallel loop collapse(3) default(present) async(1)
   do k = 1, k1
-    do j = 2, j1
-      do i = 1, i1
+    do j = 2, j2     ! i2, j2 here to include one ghost cell,
+      do i = 1, i2   ! needed for up, vp with open boundaries
         up(i,j,k)=0.
         vp(i,j,k)=0.
         wp(i,j,k)=0.
@@ -227,7 +227,7 @@ end subroutine tstep_update
 subroutine tstep_integrate
 
 
-  use modglobal, only : rdt,rk3step,e12min,i1,j1,kmax,nsv
+  use modglobal, only : rdt,rk3step,e12min,i1,j1,i2,j2,kmax,k1,nsv
   use modfields, only : u0,um,up,v0,vm,vp,w0,wm,wp,&
                         thl0,thlm,thlp,qt0,qtm,qtp,&
                         e120,e12m,e12p,sv0,svm,svp
@@ -243,9 +243,9 @@ subroutine tstep_integrate
 
   if(rk3step /= 3) then
     !$acc parallel loop collapse(3) default(present) async(1)
-    do k = 1, kmax
-      do j = 2, j1
-        do i = 1, i1
+    do k = 1, k1
+      do j = 2, j2     ! i2, j2, k1 here to include one ghost cell,
+        do i = 1, i2   ! needed for u0, v0, w0 with open boundaries
           u0(i,j,k)   = um(i,j,k)   + rk3coef * up(i,j,k)
           v0(i,j,k)   = vm(i,j,k)   + rk3coef * vp(i,j,k)
           w0(i,j,k)   = wm(i,j,k)   + rk3coef * wp(i,j,k)
@@ -273,9 +273,9 @@ subroutine tstep_integrate
 
   else ! step 3 - store result in both ..0 and ..m
     !$acc parallel loop collapse(3) default(present) async(1)
-    do k = 1, kmax
-      do j = 2, j1
-        do i = 1, i1
+    do k = 1, k1
+      do j = 2, j2     ! i2, j2, k1 here to include one ghost cell,
+        do i = 1, i2   ! needed for u0, v0, w0 with open boundaries
           um(i,j,k)   = um(i,j,k)   + rk3coef * up(i,j,k)
           u0(i,j,k)   = um(i,j,k)
           vm(i,j,k)   = vm(i,j,k)   + rk3coef * vp(i,j,k)


### PR DESCRIPTION
*land surface model*: fix sign of rain flux, add some limits and diagnostics.
*microphysics*: run only up to kmax. If microphysics is done at k1, and open boundaries keep the k1 layer raining, it can form an "infinite" rain source, since cloud water is not removed from k1.
*modgenstat*: don't use `halflev_kappa` with open boundaries, because it can cause out-of bounds accesses at the top when w != 0. This change only affects statistics, not the time stepping.