### PR TITLE
Add OpenACC directives in 5th and 6th advection schemes

### DIFF
--- a/src/advec_5th.f90
+++ b/src/advec_5th.f90
@@ -533,7 +533,7 @@ subroutine vadvecv_5th(a_in, a_out)
   end do
 
   !$acc parallel loop collapse(3) default(present) async(2)
-  do k = 1, kmax
+  do k = 4, kmax-3
     do j = 2, j1
       do i = 2, i1
         a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &

--- a/src/advec_5th.f90
+++ b/src/advec_5th.f90
@@ -49,10 +49,11 @@ subroutine hadvecc_5th(a_in, a_out)
 
   integer :: i,j,k
 
-  do k=1,kmax
-    do j=2,j1
-      do i=2,i1
-        a_out(i,j,k)  = a_out(i,j,k)- (  &
+  !$acc parallel loop collapse(3) default(present)
+  do k = 1, kmax
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k)  = a_out(i,j,k) - (  &
               ( &
                   u0(i+1,j,k)/60&
                   *(37*(a_in(i+1,j,k)+a_in(i,j,k))-8*(a_in(i+2,j,k)+a_in(i-1,j,k))+(a_in(i+3,j,k)+a_in(i-2,j,k)))&
@@ -82,7 +83,7 @@ end subroutine hadvecc_5th
 !> Vertical advection at cell center
 subroutine vadvecc_5th(a_in, a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzf
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzfi
   use modfields, only : w0, rhobf
 
   implicit none
@@ -92,93 +93,122 @@ subroutine vadvecc_5th(a_in, a_out)
 
   integer :: i,j,k
 
-
-  do k=1,kmax
-    if(k==1) then
-      do j=2,j1
-        do i=2,i1
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(1))*( &
-                w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1) + rhobf(k)*a_in(i,j,k)) &
-                ) / ( 2 * dzf(k) ) &
-                )
-        end do
-      end do
-    elseif(k==2 .or. k==kmax-1 .or. k==kmax) then
-      do j=2,j1
-        do i=2,i1
-        !CvH do 2nd order for bottom and top
-
-          a_out(i,j,k)  = a_out(i,j,k)- (  &
-              (1/rhobf(k))*( &
-                w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
-                -w0(i,j,k)  * (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
-                ) / ( 2 * dzf(k) ) &
-                )
-        end do
-      end do
-      
-    elseif(k == 3) then
-      do j=2,j1
-        do i=2,i1
-
-          a_out(i,j,k)  = a_out(i,j,k)- (  &
-              (1/rhobf(k))*( &
-                    w0(i,j,k+1)/60&
-                    *(37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))-8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1))&
-                        +(rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)))&
-                    -sign(1._field_r,w0(i,j,k+1))*w0(i,j,k+1)/60&
-                    *(10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k)*a_in(i,j,k))-5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1))&
-                        +(rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)))&
-                    -w0(i,j,k)  * (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k))/2 &
-                ) / ( dzf(k) ) &
-                )
-        end do
-      end do
-      
-    elseif(k==kmax-2) then
-      do j=2,j1
-        do i=2,i1
-            a_out(i,j,k)  = a_out(i,j,k)- (  &
-                 (1/rhobf(k))*( &
-                      w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))/2 &
-                      -w0(i,j,k)/60&
-                      *(37*(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1))-8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)))&
-                      +sign(1._field_r,w0(i,j,k))*w0(i,j,k)/60&
-                      *(10*(rhobf(k)*a_in(i,j,k)-rhobf(k-1)*a_in(i,j,k-1))-5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)))&
-                  ) / dzf(k) &
-                  )
-        end do
-      end do
-      
-    else
-      do j=2,j1
-        do i=2,i1
-
-          a_out(i,j,k)  = a_out(i,j,k)- (  &
-               (1/rhobf(k))*( &
-                    w0(i,j,k+1)/60&
-                    *(37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))-8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1))&
-                        +(rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)))&
-                    -sign(1._field_r,w0(i,j,k+1))*w0(i,j,k+1)/60&
-                    *(10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k)*a_in(i,j,k))-5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1))&
-                        +(rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)))&
-                    -w0(i,j,k)/60&
-                    *(37*(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1))-8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2))&
-                        +(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)))&
-                    +sign(1._field_r,w0(i,j,k))*w0(i,j,k)/60&
-                    *(10*(rhobf(k)*a_in(i,j,k)-rhobf(k-1)*a_in(i,j,k-1))-5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2))&
-                        +(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)))&
-                ) / dzf(k) &
-                )
-        end do
-      end do
-      
-    end if
+  k = 1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(1)) * ( &
+                    w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1) + rhobf(k)*a_in(i,j,k)) &
+              ) * ( 0.5_field_r * dzfi(k) ) &
+            )
+    end do
   end do
 
+  ! CvH do 2nd order for bottom and top
+  k = 2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+                  - w0(i,j,k  ) * (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
+              ) * ( 0.5_field_r * dzfi(k) ) &
+            )
+    end do
+  end do
+
+  k = kmax-1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+                  - w0(i,j,k  ) * (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
+              ) * ( 0.5_field_r * dzfi(k) ) &
+            )
+    end do
+  end do
+
+  k = kmax
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+                  - w0(i,j,k  ) * (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
+              ) * ( 0.5_field_r * dzfi(k) ) &
+            )
+    end do
+  end do
+
+  k = 3
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) / 60 &
+                    * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                  - sign(1._field_r,w0(i,j,k+1))*w0(i,j,k+1) / 60 &
+                    * ( 10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k  )*a_in(i,j,k  )) &
+                       - 5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)) ) &
+                  - w0(i,j,k) / 2 &
+                    *      (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k  )*a_in(i,j,k  )) &
+              ) * dzfi(k) &
+            )
+    end do
+  end do
+
+  k = kmax-2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) / 2 &
+                    *      (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                  - w0(i,j,k  ) / 60 &
+                    * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                  + sign(1._field_r,w0(i,j,k))*w0(i,j,k) / 60 &
+                    * ( 10*(rhobf(k  )*a_in(i,j,k  )-rhobf(k-1)*a_in(i,j,k-1)) &
+                       - 5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)) ) &
+              ) * dzfi(k) &
+            )
+    end do
+  end do
+
+
+  !$acc parallel loop collapse(3) default(present) async(2)
+  do k = 4, kmax-3
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                      w0(i,j,k+1) / 60 &
+                      * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                         - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - sign(1._field_r,w0(i,j,k+1))*w0(i,j,k+1) / 60 &
+                      * ( 10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k  )*a_in(i,j,k  )) &
+                         - 5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - w0(i,j,k) / 60 &
+                      * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                    + sign(1._field_r,w0(i,j,k))*w0(i,j,k) / 60 &
+                      * ( 10*(rhobf(k  )*a_in(i,j,k  )-rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)) ) &
+                ) * dzfi(k) &
+              )
+      end do
+    end do
+  end do
+  !$acc wait
 end subroutine vadvecc_5th
 
 !> Horizontal advection at the u point.
@@ -193,7 +223,7 @@ subroutine hadvecu_5th(a_in,a_out)
 
   integer :: i,j,k
 
-  !$acc parallel loop collapse(3) default(present) async(1)
+  !$acc parallel loop collapse(3) default(present)
   do k = 1, kmax
     do j = 2, j1
       do i = 2, i1
@@ -227,7 +257,7 @@ end subroutine hadvecu_5th
 !> Vertical advection at the u point.
 subroutine vadvecu_5th(a_in,a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzf
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzfi
   use modfields, only : w0, rhobf
   implicit none
 
@@ -236,91 +266,124 @@ subroutine vadvecu_5th(a_in,a_out)
 
   integer :: i,j,k
 
-  do k=1,kmax
-     if(k==1) then
-        do j=2,j1
-           do i=2,i1
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-              (1/rhobf(1))*( &
-                ( rhobf(k+1)*a_in(i,j,k+1) + rhobf(k)*a_in(i,j,k)) *(w0(i,j,k+1)+ w0(i-1,j,k+1)) &
-                ) / (4*dzf(k)) &
+  k = 1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+          (1/rhobf(1))*( &
+            ( rhobf(k+1)*a_in(i,j,k+1) + rhobf(k)*a_in(i,j,k)) *(w0(i,j,k+1)+ w0(i-1,j,k+1)) &
+            ) * (0.25_field_r * dzfi(k)) &
+            )
+    end do
+  end do
+
+  k = 2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+          (1/rhobf(k))*( &
+            (rhobf(k)*a_in(i,j,k)+rhobf(k+1)*a_in(i,j,k+1) )*(w0(i,j,k+1)+w0(i-1,j,k+1)) &
+          - (rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1) )*(w0(i,j,k  )+w0(i-1,j,k  )) &
+            ) * (0.25_field_r * dzfi(k)) &
+            )
+    end do
+  end do
+
+  k = kmax-1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+          (1/rhobf(k))*( &
+            (rhobf(k)*a_in(i,j,k)+rhobf(k+1)*a_in(i,j,k+1) )*(w0(i,j,k+1)+w0(i-1,j,k+1)) &
+          - (rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1) )*(w0(i,j,k  )+w0(i-1,j,k  )) &
+            ) * (0.25_field_r * dzfi(k)) &
+            )
+    end do
+  end do
+
+  k = kmax
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+          (1/rhobf(k))*( &
+            (rhobf(k)*a_in(i,j,k)+rhobf(k+1)*a_in(i,j,k+1) )*(w0(i,j,k+1)+w0(i-1,j,k+1)) &
+          - (rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1) )*(w0(i,j,k  )+w0(i-1,j,k  )) &
+            ) * (0.25_field_r * dzfi(k)) &
+            )
+    end do
+  end do
+
+  k = 3
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 60 &
+                    * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) )&
+                  - sign(1._field_r,(w0(i,j,k+1)+w0(i-1,j,k+1)))*(w0(i,j,k+1)+w0(i-1,j,k+1)) / 60 &
+                    * ( 10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k  )*a_in(i,j,k  )) &
+                       - 5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)) )&
+                  - ( w0(i,j,k  ) + w0(i-1,j,k  ) ) / 2 &
+                    *      (rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1) ) &
+            ) * (0.5_field_r * dzfi(k)) &
+            )
+    end do
+  end do
+
+  k = kmax-2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i-1,j,k+1)) / 2 &
+                    * ( rhobf(k)*a_in(i,j,k)+rhobf(k+1)*a_in(i,j,k+1) ) &
+                  - ( w0(i,j,k  ) + w0(i-1,j,k  )) / 60 &
+                    * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                  + sign(1._field_r,(w0(i,j,k)+w0(i-1,j,k)))*(w0(i,j,k)+w0(i-1,j,k)) / 60 &
+                    * ( 10*(rhobf(k  )*a_in(i,j,k  )-rhobf(k-1)*a_in(i,j,k-1)) &
+                       - 5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)) ) &
+            ) * (0.5_field_r * dzfi(k)) &
+            )
+    end do
+  end do
+
+  !$acc parallel loop collapse(3) default(present) async(2)
+  do k = 4, kmax-3
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                      ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 60 &
+                      * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                         - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - sign(1._field_r,(w0(i,j,k+1)+w0(i-1,j,k+1))) * (w0(i,j,k+1)+w0(i-1,j,k+1)) / 60 &
+                      * ( 10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k  )*a_in(i,j,k  )) &
+                         - 5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - ( w0(i,j,k  ) + w0(i-1,j,k) ) / 60 &
+                      * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                    + sign(1._field_r,(w0(i,j,k  )+w0(i-1,j,k  ))) * (w0(i,j,k  )+w0(i-1,j,k  )) / 60 &
+                      * ( 10*(rhobf(k  )*a_in(i,j,k  )-rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)) ) &
+                ) * (0.5_field_r * dzfi(k)) &
                 )
-       end do
+      end do
     end do
- elseif(k==2 .or. k==kmax-1 .or. k==kmax) then
-    do j=2,j1
-       do i=2,i1
-          
-          a_out(i,j,k)  = a_out(i,j,k)-( &
-              (1/rhobf(k))*( &
-                (rhobf(k)*a_in(i,j,k)+rhobf(k+1)*a_in(i,j,k+1) )*(w0(i,j,k+1)+w0(i-1,j,k+1)) &
-              -(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1) )*(w0(i,j,k  )+w0(i-1,j,k  )) &
-                ) / (4 * dzf(k)) &
-                )
-       end do
-    end do
- elseif(k==3) then
-    do j=2,j1
-       do i=2,i1
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-              (1/rhobf(k))*( &
-                      (w0(i,j,k+1)+w0(i-1,j,k+1))/60&
-                      *(37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))-8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)))&
-                      -sign(1._field_r,(w0(i,j,k+1)+w0(i-1,j,k+1)))*(w0(i,j,k+1)+w0(i-1,j,k+1))/60&
-                      *(10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k)*a_in(i,j,k))-5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)))&
-                      -(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1) )*(w0(i,j,k  )+w0(i-1,j,k  ))/2 &
-                ) / (2 * dzf(k)) &
-                )
-       end do
-    end do
- elseif(k==kmax-2) then
-    do j=2,j1
-       do i=2,i1
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(k))*(&
-                      (rhobf(k)*a_in(i,j,k)+rhobf(k+1)*a_in(i,j,k+1) )*(w0(i,j,k+1)+w0(i-1,j,k+1))/2 &
-                      -(w0(i,j,k)+w0(i-1,j,k))/60&
-                      *(37*(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1))-8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)))&
-                      +sign(1._field_r,(w0(i,j,k)+w0(i-1,j,k)))*(w0(i,j,k)+w0(i-1,j,k))/60&
-                      *(10*(rhobf(k)*a_in(i,j,k)-rhobf(k-1)*a_in(i,j,k-1))-5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)))&
-                  ) / (2 * dzf(k)) &
-                  )
-       end do
-    end do
- else
-    do j=2,j1
-       do i=2,i1
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                  (1/rhobf(k))*(&
-                      (w0(i,j,k+1)+w0(i-1,j,k+1))/60&
-                      *(37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))-8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)))&
-                      -sign(1._field_r,(w0(i,j,k+1)+w0(i-1,j,k+1)))*(w0(i,j,k+1)+w0(i-1,j,k+1))/60&
-                      *(10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k)*a_in(i,j,k))-5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)))&
-                      -(w0(i,j,k)+w0(i-1,j,k))/60&
-                      *(37*(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1))-8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)))&
-                      +sign(1._field_r,(w0(i,j,k)+w0(i-1,j,k)))*(w0(i,j,k)+w0(i-1,j,k))/60&
-                      *(10*(rhobf(k)*a_in(i,j,k)-rhobf(k-1)*a_in(i,j,k-1))-5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)))&
-                  ) / (2 * dzf(k)) &
-                  )
-
-       end do
-    end do
- end if
- 
-end do
-
-  !end if
-
+  end do
+  !$acc wait
 end subroutine vadvecu_5th
 
 !> Horizontal advection at the v point.
@@ -334,11 +397,11 @@ subroutine hadvecv_5th(a_in, a_out)
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: a_out !< Output: the tendency
   integer :: i,j,k
 
-  !$acc parallel loop collapse(3) default(present) async(2)
+  !$acc parallel loop collapse(3) default(present)
   do k = 1, kmax
     do j = 2, j1
       do i = 2, i1
-        a_out(i,j,k)  = a_out(i,j,k)- ( &
+        a_out(i,j,k)  = a_out(i,j,k) - ( &
               ( &
                   (u0(i+1,j,k)+u0(i+1,j-1,k))/60&
                   *(37*(a_in(i+1,j,k)+a_in(i,j,k))-8*(a_in(i+2,j,k)+a_in(i-1,j,k))+(a_in(i+3,j,k)+a_in(i-2,j,k)))&
@@ -369,7 +432,7 @@ end subroutine hadvecv_5th
 !> Vertical advection at the v point.
 subroutine vadvecv_5th(a_in, a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzf
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzfi
   use modfields, only : w0, rhobf
   implicit none
 
@@ -378,99 +441,124 @@ subroutine vadvecv_5th(a_in, a_out)
 
   integer :: i,j,k
 
-
-  !if (leq) then
-
-  do k=1,kmax
-     
-     if(k==1) then
-        do j=2,j1
-           do i=2,i1
-              
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(1))*( &
-                  (w0(i,j,k+1)+w0(i,j-1,k+1)) *(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
-                  ) / (4 * dzf(k)) &
-                  )
-       end do
+  k = 1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+            (1/rhobf(1))*( &
+              (w0(i,j,k+1)+w0(i,j-1,k+1)) *(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+              ) * (0.25_field_r * dzfi(k)) &
+            )
     end do
-    
- elseif(k==2 .or. k==kmax-1 .or. k==kmax) then
-    do j=2,j1
-       do i=2,i1
+  end do
 
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(k))*( &
-                  (w0(i,j,k+1)+w0(i,j-1,k+1))*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
-                -(w0(i,j,k)  +w0(i,j-1,k))  *(rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
-                  ) / (4 * dzf(k)) &
-                  )
-       end do
+  k = 2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+            (1/rhobf(k))*( &
+              (w0(i,j,k+1)+w0(i,j-1,k+1))*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+             -(w0(i,j,k  )+w0(i,j-1,k  ))*(rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
+              ) * (0.25_field_r * dzfi(k)) &
+            )
     end do
+  end do
 
- elseif(k==kmax-2) then
-    do j=2,j1
-       do i=2,i1
-
-           a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(k))*(&
-                      (w0(i,j,k+1)+w0(i,j-1,k+1))*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))/2 &
-                      -(w0(i,j,k)+w0(i,j-1,k))/60&
-                      *(37*(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1))-8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)))&
-                      +sign(1._field_r,(w0(i,j,k)+w0(i,j-1,k)))*(w0(i,j,k)+w0(i,j-1,k))/60&
-                      *(10*(rhobf(k)*a_in(i,j,k)-rhobf(k-1)*a_in(i,j,k-1))-5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)))&
-                  ) / (2 * dzf(k)) &
-                  )
-        end do
-     end do
-     
-  elseif(k==3) then
-     
-     do j=2,j1
-        do i=2,i1
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(k))*( &
-                      (w0(i,j,k+1)+w0(i,j-1,k+1))/60&
-                      *(37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))-8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)))&
-                      -sign(1._field_r,(w0(i,j,k+1)+w0(i,j-1,k+1)))*(w0(i,j,k+1)+w0(i,j-1,k+1))/60&
-                      *(10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k)*a_in(i,j,k))-5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)))&
-                      -(w0(i,j,k)  +w0(i,j-1,k))  *(rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k))/2 &
-                  ) / (2 * dzf(k)) &
-                  )
-       end do
+  k = kmax-1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+            (1/rhobf(k))*( &
+              (w0(i,j,k+1)+w0(i,j-1,k+1))*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+             -(w0(i,j,k  )+w0(i,j-1,k  ))*(rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
+              ) * (0.25_field_r * dzfi(k)) &
+            )
     end do
- else
-    do j=2,j1
-       do i=2,i1
+  end do
 
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(k))*(&
-                      (w0(i,j,k+1)+w0(i,j-1,k+1))/60&
-                      *(37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k))-8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)))&
-                      -sign(1._field_r,(w0(i,j,k+1)+w0(i,j-1,k+1)))*(w0(i,j,k+1)+w0(i,j-1,k+1))/60&
-                      *(10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k)*a_in(i,j,k))-5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1))&
-                          +(rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)))&
-                      -(w0(i,j,k)+w0(i,j-1,k))/60&
-                      *(37*(rhobf(k)*a_in(i,j,k)+rhobf(k-1)*a_in(i,j,k-1))-8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)))&
-                      +sign(1._field_r,(w0(i,j,k)+w0(i,j-1,k)))*(w0(i,j,k)+w0(i,j-1,k))/60&
-                      *(10*(rhobf(k)*a_in(i,j,k)-rhobf(k-1)*a_in(i,j,k-1))-5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2))&
-                          +(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)))&
-                  ) / (2 * dzf(k)) &
-                  )
-       end do
+  k = kmax
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( &
+            (1/rhobf(k))*( &
+              (w0(i,j,k+1)+w0(i,j-1,k+1))*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+             -(w0(i,j,k  )+w0(i,j-1,k  ))*(rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
+              ) * (0.25_field_r * dzfi(k)) &
+            )
     end do
- end if
-end do
+  end do
 
-  !end if
+  k = 3
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k)- ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 60 &
+                    * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                  - sign(1._field_r,(w0(i,j,k+1)+w0(i,j-1,k+1)))*(w0(i,j,k+1)+w0(i,j-1,k+1)) / 60 &
+                    * ( 10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k  )*a_in(i,j,k  )) &
+                       - 5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)) ) &
+                  - ( w0(i,j,k  ) + w0(i,j-1,k  ) ) / 2 &
+                    * (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k)*a_in(i,j,k)) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    end do
+  end do
 
+  k = kmax-2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 2 &
+                     * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k)*a_in(i,j,k)) &
+                  - ( w0(i,j,k  ) + w0(i,j-1,k  ) ) / 60 &
+                     * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                        - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                        +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                  + sign(1._field_r,(w0(i,j,k)+w0(i,j-1,k)))*(w0(i,j,k)+w0(i,j-1,k)) / 60 &
+                     * ( 10*(rhobf(k  )*a_in(i,j,k  )-rhobf(k-1)*a_in(i,j,k-1)) &
+                        - 5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2)) &
+                        +   (rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)) ) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    end do
+  end do
+
+  !$acc parallel loop collapse(3) default(present) async(2)
+  do k = 1, kmax
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                      ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 60 &
+                      * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                         - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - sign(1._field_r,(w0(i,j,k+1)+w0(i,j-1,k+1)))*(w0(i,j,k+1)+w0(i,j-1,k+1)) / 60 &
+                      * ( 10*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k  )*a_in(i,j,k  )) &
+                         - 5*(rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)-rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - ( w0(i,j,k) + w0(i,j-1,k) ) / 60&
+                      * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                    + sign(1._field_r,(w0(i,j,k)+w0(i,j-1,k)))*(w0(i,j,k)+w0(i,j-1,k)) / 60 &
+                      * ( 10*(rhobf(k  )*a_in(i,j,k  )-rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 5*(rhobf(k+1)*a_in(i,j,k+1)-rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)-rhobf(k-3)*a_in(i,j,k-3)) ) &
+                ) * (0.5_field_r * dzfi(k)) &
+              )
+      end do
+    end do
+  end do
+  !$acc wait
 end subroutine vadvecv_5th
 
 subroutine hadvecw_5th(a_in, a_out)
@@ -484,7 +572,7 @@ subroutine hadvecw_5th(a_in, a_out)
 
   integer :: i,j,k
 
-  !$acc parallel loop collapse(3) default(present) async(3)
+  !$acc parallel loop collapse(3) default(present)
   do k = 2, kmax
     do j = 2, j1
       do i = 2, i1
@@ -513,14 +601,12 @@ subroutine hadvecw_5th(a_in, a_out)
       end do
     end do
   end do
-  !Advection for u, v and w called sequentially in modavection. Only sync here.
-  !$acc wait(1,2,3)
 end subroutine hadvecw_5th
 
 !> Vertical advection at the w point.
 subroutine vadvecw_5th(a_in, a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzh
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzhi
   use modfields, only : w0, rhobh
   implicit none
 
@@ -529,81 +615,107 @@ subroutine vadvecw_5th(a_in, a_out)
 
   integer :: i,j,k
 
+  k = 2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - (  (1/rhobh(k)) * ( &
+                     ( rhobh(k)*a_in(i,j,k)+rhobh(k+1)*a_in(i,j,k+1) )*(w0(i,j,k) + w0(i,j,k+1)) &
+                   - ( rhobh(k)*a_in(i,j,k)+rhobh(k-1)*a_in(i,j,k-1) )*(w0(i,j,k) + w0(i,j,k-1)) &
+                  ) * (0.25_field_r * dzhi(k)) &
+            )
+    end do
+  end do
 
-  do k=2,kmax
-     if(k==2 .or. k==kmax-1 .or. k==kmax) then
-        do j=2,j1
-           do i=2,i1
+  k = kmax-1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - (  (1/rhobh(k)) * ( &
+                     ( rhobh(k)*a_in(i,j,k)+rhobh(k+1)*a_in(i,j,k+1) )*(w0(i,j,k) + w0(i,j,k+1)) &
+                   - ( rhobh(k)*a_in(i,j,k)+rhobh(k-1)*a_in(i,j,k-1) )*(w0(i,j,k) + w0(i,j,k-1)) &
+                  ) * (0.25_field_r * dzhi(k)) &
+            )
+    end do
+  end do
 
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobh(k))*( &
-                  (rhobh(k)*a_in(i,j,k)+rhobh(k+1)*a_in(i,j,k+1) )*(w0(i,j,k) + w0(i,j,k+1)) &
-                -(rhobh(k)*a_in(i,j,k)+rhobh(k-1)*a_in(i,j,k-1) )*(w0(i,j,k) + w0(i,j,k-1)) &
-                  )/ (4 * dzh(k)) &
-                  )
-         end do
+  k = kmax
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - (  (1/rhobh(k)) * ( &
+                     ( rhobh(k)*a_in(i,j,k)+rhobh(k+1)*a_in(i,j,k+1) )*(w0(i,j,k) + w0(i,j,k+1)) &
+                   - ( rhobh(k)*a_in(i,j,k)+rhobh(k-1)*a_in(i,j,k-1) )*(w0(i,j,k) + w0(i,j,k-1)) &
+                  ) * (0.25_field_r * dzhi(k)) &
+            )
+    end do
+  end do
+
+  k = 3
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                    ( w0(i,j,k) + w0(i,j,k+1) ) / 60 &
+                    * ( 37*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobh(k+3)*a_in(i,j,k+3)+rhobh(k-2)*a_in(i,j,k-2)) ) &
+                  - sign(1._field_r,(w0(i,j,k)+w0(i,j,k+1)))*(w0(i,j,k)+w0(i,j,k+1)) / 60 &
+                    * ( 10*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k  )*a_in(i,j,k  )) &
+                       - 5*(rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobh(k+3)*a_in(i,j,k+3)-rhobh(k-2)*a_in(i,j,k-2)) ) &
+                  - (w0(i,j,k) + w0(i,j,k-1)) / 2 &
+                    *      (rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+              ) * (0.5_field_r * dzhi(k)) &
+            )
+    end do
+  end do
+
+  k = kmax-2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                    ( w0(i,j,k) + w0(i,j,k+1) ) / 2 &
+                     *      (rhobh(k  )*a_in(i,j,k  )+rhobh(k+1)*a_in(i,j,k+1)) &
+                  - ( w0(i,j,k) + w0(i,j,k-1) ) / 60 &
+                     * ( 37*(rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+                        - 8*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2)) &
+                        +   (rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-3)*a_in(i,j,k-3)) ) &
+                  + sign(1._field_r,(w0(i,j,k)+w0(i,j,k-1)))*(w0(i,j,k)+w0(i,j,k-1)) / 60 &
+                     * ( 10*(rhobh(k  )*a_in(i,j,k  )-rhobh(k-1)*a_in(i,j,k-1)) &
+                        - 5*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k-2)*a_in(i,j,k-2)) &
+                        +   (rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-3)*a_in(i,j,k-3)) ) &
+              ) * (0.5_field_r * dzhi(k)) &
+            )
+    end do
+  end do
+
+  do k = 4, kmax-3
+    do j = 2, j1
+      do i = 2, i1
+         a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                       ( w0(i,j,k) + w0(i,j,k+1) ) / 60 &
+                        * ( 37*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k  )*a_in(i,j,k  )) &
+                           - 8*(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1)) &
+                           +   (rhobh(k+3)*a_in(i,j,k+3)+rhobh(k-2)*a_in(i,j,k-2)) ) &
+                     - sign(1._field_r,(w0(i,j,k)+w0(i,j,k+1)))*(w0(i,j,k)+w0(i,j,k+1)) / 60 &
+                        * ( 10*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k  )*a_in(i,j,k  )) &
+                           - 5*(rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-1)*a_in(i,j,k-1)) &
+                           +   (rhobh(k+3)*a_in(i,j,k+3)-rhobh(k-2)*a_in(i,j,k-2)) ) &
+                     - ( w0(i,j,k) + w0(i,j,k-1) ) / 60 &
+                        * ( 37*(rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+                           - 8*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2)) &
+                           +   (rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-3)*a_in(i,j,k-3)) ) &
+                     + sign(1._field_r,(w0(i,j,k)+w0(i,j,k-1)))*(w0(i,j,k)+w0(i,j,k-1)) / 60 &
+                        * ( 10*(rhobh(k  )*a_in(i,j,k  )-rhobh(k-1)*a_in(i,j,k-1)) &
+                           - 5*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k-2)*a_in(i,j,k-2)) &
+                           +   (rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-3)*a_in(i,j,k-3)) ) &
+                 ) * (0.5_field_r * dzhi(k)) &
+               )
       end do
-   elseif(k==3) then
-      do j=2,j1
-         do i=2,i1
-            
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobh(k))*( &
-                      (w0(i,j,k)+w0(i,j,k+1))/60&
-                      *(37*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k)*a_in(i,j,k))-8*(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1))&
-                          +(rhobh(k+3)*a_in(i,j,k+3)+rhobh(k-2)*a_in(i,j,k-2)))&
-                      -sign(1._field_r,(w0(i,j,k)+w0(i,j,k+1)))*(w0(i,j,k)+w0(i,j,k+1))/60&
-                      *(10*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k)*a_in(i,j,k))-5*(rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-1)*a_in(i,j,k-1))&
-                          +(rhobh(k+3)*a_in(i,j,k+3)-rhobh(k-2)*a_in(i,j,k-2)))&
-                      -(rhobh(k)*a_in(i,j,k)+rhobh(k-1)*a_in(i,j,k-1) )*(w0(i,j,k) + w0(i,j,k-1))/2 &
-                  )/ (2 * dzh(k)) &
-                  )
-         end do
-      end do
-   elseif(k==kmax-2) then
-      do j=2,j1
-         do i=2,i1
-
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobh(k))*(&
-                  (rhobh(k)*a_in(i,j,k)+rhobh(k+1)*a_in(i,j,k+1) )*(w0(i,j,k) + w0(i,j,k+1))/2 &
-                  -(w0(i,j,k)+w0(i,j,k-1))/60&
-                  *(37*(rhobh(k)*a_in(i,j,k)+rhobh(k-1)*a_in(i,j,k-1))-8*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2))&
-                      +(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-3)*a_in(i,j,k-3)))&
-                  +sign(1._field_r,(w0(i,j,k)+w0(i,j,k-1)))*(w0(i,j,k)+w0(i,j,k-1))/60&
-                  *(10*(rhobh(k)*a_in(i,j,k)-rhobh(k-1)*a_in(i,j,k-1))-5*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k-2)*a_in(i,j,k-2))&
-                      +(rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-3)*a_in(i,j,k-3)))&
-                  ) / (2 * dzh(k)) &
-                  )
-         end do
-      end do
-   else
-      do j=2,j1
-         do i=2,i1
-
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobh(k))*(&
-                  (w0(i,j,k)+w0(i,j,k+1))/60&
-                  *(37*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k)*a_in(i,j,k))-8*(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1))&
-                      +(rhobh(k+3)*a_in(i,j,k+3)+rhobh(k-2)*a_in(i,j,k-2)))&
-                  -sign(1._field_r,(w0(i,j,k)+w0(i,j,k+1)))*(w0(i,j,k)+w0(i,j,k+1))/60&
-                  *(10*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k)*a_in(i,j,k))-5*(rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-1)*a_in(i,j,k-1))&
-                      +(rhobh(k+3)*a_in(i,j,k+3)-rhobh(k-2)*a_in(i,j,k-2)))&
-                  -(w0(i,j,k)+w0(i,j,k-1))/60&
-                  *(37*(rhobh(k)*a_in(i,j,k)+rhobh(k-1)*a_in(i,j,k-1))-8*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2))&
-                      +(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-3)*a_in(i,j,k-3)))&
-                  +sign(1._field_r,(w0(i,j,k)+w0(i,j,k-1)))*(w0(i,j,k)+w0(i,j,k-1))/60&
-                  *(10*(rhobh(k)*a_in(i,j,k)-rhobh(k-1)*a_in(i,j,k-1))-5*(rhobh(k+1)*a_in(i,j,k+1)-rhobh(k-2)*a_in(i,j,k-2))&
-                      +(rhobh(k+2)*a_in(i,j,k+2)-rhobh(k-3)*a_in(i,j,k-3)))&
-                  ) / (2 * dzh(k)) &
-                  )
-
-         end do
-      end do
-   end if
-end do
-
-  !end if
-
+    end do
+  end do
+  !$acc wait
 end subroutine vadvecw_5th
 end module advec_5th

--- a/src/advec_6th.f90
+++ b/src/advec_6th.f90
@@ -41,7 +41,7 @@ subroutine hadvecc_6th(a_in, a_out)
 
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in)  :: a_in !< Input: the cell centered field
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: a_out !< Output: the tendency
-  
+
   integer :: i,j,k
 
   !$acc parallel loop collapse(3) default(present)
@@ -190,7 +190,7 @@ subroutine hadvecu_6th(a_in,a_out)
 
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in)  :: a_in !< Input: the u field
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: a_out !< Output: the tendency
-  
+
   integer :: i,j,k
 
   !$acc parallel loop collapse(3) default(present)

--- a/src/advec_6th.f90
+++ b/src/advec_6th.f90
@@ -148,11 +148,11 @@ subroutine vadvecc_6th(a_in, a_out)
   !$acc parallel loop collapse(2) default(present) async(1)
   do j = 2, j1
     do i = 2, i1
-      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k))*( &
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
                     w0(i,j,k+1) / 2 &
                     *     (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
                   - w0(i,j,k  ) / 12 &
-                    * ( 7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1))
+                    * ( 7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
                        -  (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) ) &
               ) * dzfi(k) &
             )
@@ -247,7 +247,7 @@ subroutine vadvecu_6th(a_in,a_out)
     do i = 2, i1
       a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
                     ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 12 &
-                    * ( 7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  ))
+                    * ( 7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
                        -  (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) ) &
                   - ( w0(i,j,k  ) + w0(i-1,j,k  ) ) / 2 &
                     *     (rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &

--- a/src/advec_6th.f90
+++ b/src/advec_6th.f90
@@ -44,11 +44,11 @@ subroutine hadvecc_6th(a_in, a_out)
   
   integer :: i,j,k
 
-  !$acc parallel loop collapse(3) default(present) async(2)
+  !$acc parallel loop collapse(3) default(present)
   do k = 1, kmax
     do j = 2, j1
       do i = 2, i1
-        a_out(i,j,k)  = a_out(i,j,k)- (  &
+        a_out(i,j,k) = a_out(i,j,k) - (  &
             ( &
                 u0(i+1,j,k)/60 &
                 *(37*(a_in(i+1,j,k)+a_in(i,j,k))-8*(a_in(i+2,j,k)+a_in(i-1,j,k))+(a_in(i+3,j,k)+a_in(i-2,j,k)))&
@@ -65,102 +65,119 @@ subroutine hadvecc_6th(a_in, a_out)
       end do
     end do
   end do
-  !$acc wait(1,2)
 end subroutine hadvecc_6th
 
 !> Vertical advection at cell center
 subroutine vadvecc_6th(a_in, a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzf
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzfi
   use modfields, only : w0, rhobf
 
   implicit none
 
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in) :: a_in
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: a_out
-  real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1) :: rho_a_in
 
   integer :: i,j,k
 
-!   if (leq) then
-
-  do k=1,k1
-    do j=2-jh,j1+jh
-      do i=2-ih,i1+ih
-      rho_a_in(i,j,k)=rhobf(k)*a_in(i,j,k)
-      end do
+  k = 1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(1)) * ( &
+                    w0(i,j,k+1) * (rhobf(k+1)*a_in(i,j,k+1) + rhobf(k)*a_in(i,j,k)) &
+              ) * ( 0.5_field_r * dzfi(k) ) &
+            )
     end do
   end do
 
-  do k=1,kmax
-    do j=2,j1
-      do i=2,i1
-
-        if(k==1) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobf(1))*( &
-                w0(i,j,k+1) * (rho_a_in(i,j,k+1) + rho_a_in(i,j,k)) / 2 &
-                ) / dzf(k) &
-                )
-        elseif(k==2) then
-        !CvH do 2nd order for influx and 4th order for outflux
-            a_out(i,j,k)  = a_out(i,j,k)- (  &
-                (1/rhobf(k))*( &
-                      w0(i,j,k+1) / 12 &
-                      *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1)))&
-                      - w0(i,j,k)  * (rho_a_in(i,j,k-1)+rho_a_in(i,j,k)) / 2 &
-                  ) / dzf(k) &
-                  )
-        elseif(k == 3) then
-        !CvH do 6th order for outflux and 4th for influx
-            a_out(i,j,k)  = a_out(i,j,k)- (  &
-                (1/rhobf(k))*( &
-                      w0(i,j,k+1)/60 &
-                      *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                           +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                      -w0(i,j,k)/12 &
-                      *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2)))&
-                  )/dzf(k) &
-                  )
-        elseif(k==kmax-1) then
-        !CvH do 6th order for influx and 4th order for outflux
-            a_out(i,j,k)  = a_out(i,j,k)- (  &
-                 (1/rhobf(k))*( &
-                      w0(i,j,k+1)/12 &
-                      *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1)))&
-                      -w0(i,j,k)/60 &
-                      *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                          +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                  )/dzf(k) &
-                  )
-         elseif(k==kmax) then
-        !CvH do 4th order for influx and 2nd order for outflux
-            a_out(i,j,k)  = a_out(i,j,k)- (  &
-                (1/rhobf(k))*( &
-                     w0(i,j,k+1) * (rho_a_in(i,j,k+1)+rho_a_in(i,j,k)) / 2 &
-                     -w0(i,j,k)/12 &
-                     *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2)))&
-                  )/dzf(k) &
-                  )
-        else
-            a_out(i,j,k)  = a_out(i,j,k)- (  &
-                (1/rhobf(k))*(&
-                      w0(i,j,k+1)/60 &
-                      *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                          +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                      -w0(i,j,k)/60 &
-                      *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                          +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                  )/dzf(k) &
-                  )
-        end if
-      end do
+  k = 2
+  !CvH do 2nd order for influx and 4th order for outflux
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) / 12 &
+                    * ( 7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       -  (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)))&
+                  - w0(i,j,k  ) / 2 &
+                    *     (rhobf(k-1)*a_in(i,j,k-1)+rhobf(k  )*a_in(i,j,k  )) &
+              ) * dzfi(k) &
+            )
     end do
   end do
 
-!   end if
+  k = 3
+  !CvH do 6th order for outflux and 4th for influx
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) / 60 &
+                    * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                  - w0(i,j,k  ) / 12 &
+                    * (  7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       -   (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+              ) * dzfi(k) &
+            )
+    end do
+  end do
 
+  k = kmax-1
+  !CvH do 6th order for influx and 4th order for outflux
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    w0(i,j,k+1) / 12 &
+                    * (  7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       -   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) ) &
+                  - w0(i,j,k  ) / 60 &
+                    * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+              ) * dzfi(k) &
+            )
+    end do
+  end do
+
+  k = kmax
+  !CvH do 4th order for influx and 2nd order for outflux
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k))*( &
+                    w0(i,j,k+1) / 2 &
+                    *     (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                  - w0(i,j,k  ) / 12 &
+                    * ( 7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1))
+                       -  (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+              ) * dzfi(k) &
+            )
+    end do
+  end do
+
+  !$acc parallel loop collapse(3) default(present) async(2)
+  do k = 4, kmax-2
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                      w0(i,j,k+1) / 60 &
+                      * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                         - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - w0(i,j,k  ) / 60 &
+                      * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                ) * dzfi(k) &
+              )
+      end do
+    end do
+  end do
+  !$acc wait
 end subroutine vadvecc_6th
 
 !> Horizontal advection at the u point.
@@ -176,7 +193,7 @@ subroutine hadvecu_6th(a_in,a_out)
   
   integer :: i,j,k
 
-  !$acc parallel loop collapse(3) default(present) async(1)
+  !$acc parallel loop collapse(3) default(present)
   do k = 1, kmax
     do j = 2, j1
       do i = 2, i1
@@ -202,104 +219,111 @@ end subroutine hadvecu_6th
 !> Vertical advection at the u point.
 subroutine vadvecu_6th(a_in,a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzf
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzfi
   use modfields, only : w0, rhobf
 
   implicit none
 
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in)  :: a_in !< Input: the u field
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: a_out !< Output: the tendency
-  real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1) :: rho_a_in
 
   integer :: i,j,k
 
+  k = 1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(1)) * ( &
+                    ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 2 &
+                    * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
 
-  do k=1,k1
-    do j=2-jh,j1+jh
-      do i=2-ih,i1+ih
-      rho_a_in(i,j,k)=rhobf(k)*a_in(i,j,k)
+  k = 2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 12 &
+                    * ( 7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  ))
+                       -  (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) ) &
+                  - ( w0(i,j,k  ) + w0(i-1,j,k  ) ) / 2 &
+                    *     (rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  k = 3
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 60 &
+                    * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                  - ( w0(i,j,k  ) + w0(i-1,j,k  ) ) / 12 &
+                    * (  7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       -   (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  k = kmax-1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 12 &
+                    * (  7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       -   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) ) &
+                  - ( w0(i,j,k  ) + w0(i-1,j,k  ) ) / 60 &
+                    * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  k = kmax
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 2 &
+                    *     (rhobf(k  )*a_in(i,j,k  )+rhobf(k+1)*a_in(i,j,k+1)) &
+                  - ( w0(i,j,k  ) + w0(i-1,j,k  ) ) / 12 &
+                    * ( 7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       -  (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) )&
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  !$acc parallel loop collapse(3) default(present) async(2)
+  do k = 4, kmax-2
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                      ( w0(i,j,k+1) + w0(i-1,j,k+1) ) / 60 &
+                      * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                         - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - ( w0(i,j,k  ) + w0(i-1,j,k  ) ) / 60 &
+                      * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                  ) * (0.5_field_r * dzfi(k)) &
+                )
       end do
     end do
   end do
-
-!   if (leq) then
-
-    do k=1,kmax
-      do j=2,j1
-        do i=2,i1
-
-        if(k==1) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-               (1/rhobf(1))*( &
-                    (rho_a_in(i,j,k+1) + rho_a_in(i,j,k)) *(w0(i,j,k+1)+w0(i-1,j,k+1)) / 2 &
-                )/(2*dzf(k)) &
-                )
-
-        elseif(k==2) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-               (1/rhobf(k))*( &
-                    (w0(i,j,k+1)+w0(i-1,j,k+1))/12 &
-                    *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1)))&
-                    -(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))*(w0(i,j,k)+w0(i-1,j,k)) / 2 &
-                ) / (2*dzf(k)) &
-                )
-
-        elseif(k==3) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-               (1/rhobf(k))*( &
-                    (w0(i,j,k+1)+w0(i-1,j,k+1))/60 &
-                    *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                        +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                    -(w0(i,j,k)+w0(i-1,j,k))/12 &
-                    *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2)))&
-                ) / (2*dzf(k)) &
-                )
-
-        elseif(k==kmax-1) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-               (1/rhobf(k))*( &
-                    (w0(i,j,k+1)+w0(i-1,j,k+1))/12 &
-                    *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1)))&
-                    -(w0(i,j,k)+w0(i-1,j,k))/60 &
-                    *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                        +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                ) / (2*dzf(k)) &
-                )
- 
-        elseif(k==kmax) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-               (1/rhobf(k))*( &
-                    (rho_a_in(i,j,k)+rho_a_in(i,j,k+1))*(w0(i,j,k+1)+w0(i-1,j,k+1))/2 &
-                    -(w0(i,j,k)+w0(i-1,j,k))/12 &
-                    *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2)))&
-                ) / (2*dzf(k)) &
-                )
-       
-        else
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                  (1/rhobf(k))*(&
-                      (w0(i,j,k+1)+w0(i-1,j,k+1))/60 &
-                      *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                          +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                      -(w0(i,j,k)+w0(i-1,j,k))/60 &
-                      *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                          +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                  ) / (2*dzf(k)) &
-                  )
-        end if
-
-        end do
-      end do
-    end do
-
-!   end if
-
+  !$acc wait
 end subroutine vadvecu_6th
 
 !> Horizontal advection at the v point.
@@ -314,7 +338,7 @@ subroutine hadvecv_6th(a_in, a_out)
 
   integer :: i,j,k
 
-  !$acc parallel loop collapse(3) default(present) async(2)
+  !$acc parallel loop collapse(3) default(present)
   do k = 1, kmax
     do j = 2, j1
       do i = 2, i1
@@ -340,104 +364,110 @@ end subroutine hadvecv_6th
 !> Vertical advection at the v point.
 subroutine vadvecv_6th(a_in, a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzf
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzfi
   use modfields, only : w0, rhobf
   implicit none
 
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in)  :: a_in !< Input: the v field
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: a_out !< Output: the tendency
-  real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1) :: rho_a_in
 
   integer :: i,j,k
 
-  do k=1,k1
-    do j=2-jh,j1+jh
-      do i=2-ih,i1+ih
-      rho_a_in(i,j,k)=rhobf(k)*a_in(i,j,k)
+  k = 1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(1)) * ( &
+                    ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 2 &
+                    * (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                ) * (0.5_field_r * dzfi(k)) &
+              )
+    enddo
+  enddo
+
+  k = 2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 12 &
+                   * ( 7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                      -  (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) ) &
+                  - ( w0(i,j,k  ) + w0(i,j-1,k  ) ) / 2 &
+                   *     (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  k = 3
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 60 &
+                    * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                  - ( w0(i,j,k  ) + w0(i,j-1,k  ) ) / 12 &
+                    * (  7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       -   (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  k = kmax-1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 12 &
+                    * (  7*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                       -   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) ) &
+                  - ( w0(i,j,k  ) + w0(i,j-1,k  ) ) / 60 &
+                    * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  k = kmax
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                    ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 2 &
+                    *     (rhobf(k  )*a_in(i,j,k  )+rhobf(k+1)*a_in(i,j,k+1)) &
+                  - ( w0(i,j,k  ) + w0(i,j-1,k  ) ) / 12 &
+                    * ( 7*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                       -  (rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) )&
+              ) * (0.5_field_r * dzfi(k)) &
+            )
+    enddo
+  enddo
+
+  !$acc parallel loop collapse(3) default(present) async(2)
+  do k = 4, kmax-2
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobf(k)) * ( &
+                      ( w0(i,j,k+1) + w0(i,j-1,k+1) ) / 60 &
+                      * ( 37*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k  )*a_in(i,j,k  )) &
+                         - 8*(rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobf(k+3)*a_in(i,j,k+3)+rhobf(k-2)*a_in(i,j,k-2)) ) &
+                    - ( w0(i,j,k  ) + w0(i,j-1,k  ) ) / 60 &
+                      * ( 37*(rhobf(k  )*a_in(i,j,k  )+rhobf(k-1)*a_in(i,j,k-1)) &
+                         - 8*(rhobf(k+1)*a_in(i,j,k+1)+rhobf(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobf(k+2)*a_in(i,j,k+2)+rhobf(k-3)*a_in(i,j,k-3)) ) &
+                  ) * (0.5_field_r * dzfi(k)) &
+                )
       end do
     end do
   end do
-
-!   if (leq) then
-
-    do k=1,kmax
-      do j=2,j1
-        do i=2,i1
-
-        if(k==1) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                 (1/rhobf(1))*( &
-                    (w0(i,j,k+1)+w0(i,j-1,k+1)) *(rho_a_in(i,j,k+1)+rho_a_in(i,j,k)) / 2&
-                  ) / (2*dzf(k)) &
-                  )
-
-        elseif(k==2) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                 (1/rhobf(k))*( &
-                    (w0(i,j,k+1)+w0(i,j-1,k+1))/12 &
-                    *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1)))&
-                    -(w0(i,j,k)  +w0(i,j-1,k))  *(rho_a_in(i,j,k-1)+rho_a_in(i,j,k)) / 2&
-                  )/(2*dzf(k)) &
-                  )
-
-        elseif(k==3) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                 (1/rhobf(k))*( &
-                    (w0(i,j,k+1)+w0(i,j-1,k+1))/60 &
-                    *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                        +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                    -(w0(i,j,k)+w0(i,j-1,k))/12 &
-                    *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2)))&
-                  )/(2*dzf(k)) &
-                  )
-
-        elseif(k==kmax-1) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                 (1/rhobf(k))*( &
-                    (w0(i,j,k+1)+w0(i,j-1,k+1))/12 &
-                    *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1)))&
-                    -(w0(i,j,k)+w0(i,j-1,k))/60 &
-                    *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                        +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                  ) / (2*dzf(k)) &
-                  )
-
-        elseif(k==kmax) then
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                 (1/rhobf(k))*( &
-                    (w0(i,j,k+1)+w0(i,j-1,k+1))*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k)) / 2&
-                    -(w0(i,j,k)+w0(i,j-1,k))/12 &
-                    *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2)))&
-                  ) / (2*dzf(k)) &
-                  )
-
-        else
-
-          a_out(i,j,k)  = a_out(i,j,k)- ( &
-                 (1/rhobf(k))*(&
-                      (w0(i,j,k+1)+w0(i,j-1,k+1))/60 &
-                      *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                          +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                      -(w0(i,j,k)+w0(i,j-1,k))/60 &
-                      *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                          +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                  ) / (2*dzf(k)) &
-                  )
-
-        end if
-
-        end do
-      end do
-    end do
-
-
-!   end if
-
+  !$acc wait
 end subroutine vadvecv_6th
 
 !> Horiontal advection at the w point.
@@ -452,7 +482,7 @@ subroutine hadvecw_6th(a_in, a_out)
 
   integer :: i,j,k
 
-  !$acc parallel loop collapse(3) default(present) async(3)
+  !$acc parallel loop collapse(3) default(present)
   do k = 2, kmax
     do j = 2, j1
       do i = 2, i1
@@ -480,87 +510,97 @@ end subroutine hadvecw_6th
 !> Vertical advection at the w point.
 subroutine vadvecw_6th(a_in, a_out)
 
-  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzh
+  use modglobal, only : i1,ih,j1,jh,k1,kmax,dzhi
   use modfields, only : w0, rhobh
   implicit none
 
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(in)  :: a_in !< Input: the w field
   real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1), intent(inout) :: a_out !< Output: the tendency
-  real(field_r), dimension(2-ih:i1+ih,2-jh:j1+jh,k1) :: rho_a_in
 
   integer :: i,j,k
 
-
-  do k=1,k1
-    do j=2-jh,j1+jh
-      do i=2-ih,i1+ih
-      rho_a_in(i,j,k)=rhobh(k)*a_in(i,j,k)
-      end do
+  k = 2
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                    ( w0(i,j,k) + w0(i,j,k+1) ) / 12 &
+                    * ( 7*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k  )*a_in(i,j,k  )) &
+                       -  (rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1)) ) &
+                  - ( w0(i,j,k) + w0(i,j,k-1) ) / 2 &
+                    *     (rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+              ) * (0.5_field_r * dzhi(k)) &
+            )
     end do
   end do
 
-!   if (leq) then
+  k = 3
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                    ( w0(i,j,k) + w0(i,j,k+1) ) / 60 &
+                    * ( 37*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k  )*a_in(i,j,k  )) &
+                       - 8*(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1)) &
+                       +   (rhobh(k+3)*a_in(i,j,k+3)+rhobh(k-2)*a_in(i,j,k-2)) ) &
+                  - ( w0(i,j,k) + w0(i,j,k-1) ) / 12 &
+                    * (  7*(rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+                       -   (rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2)) ) &
+              ) * (0.5_field_r * dzhi(k)) &
+            )
+    end do
+  end do
 
-    do k=2,kmax
-      do j=2,j1
-        do i=2,i1
+  k = kmax-1
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                    ( w0(i,j,k) + w0(i,j,k+1) ) / 12 &
+                    * (  7*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k  )*a_in(i,j,k  )) &
+                       -   (rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1)) ) &
+                  - ( w0(i,j,k) + w0(i,j,k-1) ) / 60 &
+                    * ( 37*(rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+                       - 8*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2)) &
+                       +   (rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-3)*a_in(i,j,k-3)) ) &
+              ) * (0.5_field_r * dzhi(k)) &
+            )
+    end do
+  end do
 
-          if(k==2) then
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                  (1/rhobh(k))*( &
-                     (w0(i,j,k)+w0(i,j,k+1))/12 &
-                     *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1)))&
-                     -(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))*(w0(i,j,k) + w0(i,j,k-1)) / 2 &
-                  )/(2*dzh(k)) &
-                  )
- 
-          elseif(k==3) then
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                (1/rhobh(k))*( &
-                     (w0(i,j,k)+w0(i,j,k+1))/60 &
-                     *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                         +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                     -(w0(i,j,k)+w0(i,j,k-1))/12 &
-                     *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))) &
-                  )/(2*dzh(k)) &
-                  )
+  k = kmax
+  !$acc parallel loop collapse(2) default(present) async(1)
+  do j = 2, j1
+    do i = 2, i1
+      a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                    ( w0(i,j,k) + w0(i,j,k+1) ) / 2 &
+                    *    (rhobh(k  )*a_in(i,j,k  )+rhobh(k+1)*a_in(i,j,k+1)) &
+                  - ( w0(i,j,k) + w0(i,j,k-1) ) /12 &
+                    *( 7*(rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+                      -  (rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2)) ) &
+              ) * (0.5_field_r * dzhi(k)) &
+            )
+    end do
+  end do
 
-          elseif(k==kmax-1) then
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                  (1/rhobh(k))*( &
-                     (w0(i,j,k)+w0(i,j,k+1))/12 &
-                     *(7*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))) &
-                     -(w0(i,j,k)+w0(i,j,k-1))/60 &
-                     *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                         +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                  )/(2*dzh(k)) &
-                  )
-
-          elseif(k==kmax) then
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                  (1/rhobh(k))*( &
-                     (rho_a_in(i,j,k)+rho_a_in(i,j,k+1) )*(w0(i,j,k) + w0(i,j,k+1)) / 2 &
-                     -(w0(i,j,k)+w0(i,j,k-1))/12 &
-                     *(7*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))) &
-                  ) / (2*dzh(k)) &
-                  )
- 
-          else
-
-            a_out(i,j,k)  = a_out(i,j,k)- ( &
-                  (1/rhobh(k))*(&
-                      (w0(i,j,k)+w0(i,j,k+1))/60 &
-                      *(37*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k))-8*(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-1))&
-                          +(rho_a_in(i,j,k+3)+rho_a_in(i,j,k-2)))&
-                      -(w0(i,j,k)+w0(i,j,k-1))/60 &
-                      *(37*(rho_a_in(i,j,k)+rho_a_in(i,j,k-1))-8*(rho_a_in(i,j,k+1)+rho_a_in(i,j,k-2))&
-                          +(rho_a_in(i,j,k+2)+rho_a_in(i,j,k-3)))&
-                  ) / (2*dzh(k)) &
-                  )
-          end if
-        end do
+  !$acc parallel loop collapse(3) default(present) async(2)
+  do k = 4, kmax-2
+    do j = 2, j1
+      do i = 2, i1
+        a_out(i,j,k) = a_out(i,j,k) - ( (1/rhobh(k)) * ( &
+                      ( w0(i,j,k) + w0(i,j,k+1) ) / 60 &
+                      * ( 37*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k  )*a_in(i,j,k  )) &
+                         - 8*(rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-1)*a_in(i,j,k-1)) &
+                         +   (rhobh(k+3)*a_in(i,j,k+3)+rhobh(k-2)*a_in(i,j,k-2)) ) &
+                    - ( w0(i,j,k) + w0(i,j,k-1) ) / 60 &
+                      * ( 37*(rhobh(k  )*a_in(i,j,k  )+rhobh(k-1)*a_in(i,j,k-1)) &
+                         - 8*(rhobh(k+1)*a_in(i,j,k+1)+rhobh(k-2)*a_in(i,j,k-2)) &
+                         +   (rhobh(k+2)*a_in(i,j,k+2)+rhobh(k-3)*a_in(i,j,k-3)) ) &
+                ) * (0.5_field_r * dzhi(k)) &
+              )
       end do
     end do
-
+  end do
+  !$acc wait
 end subroutine vadvecw_6th
 end module advec_6th


### PR DESCRIPTION
 - removing the rho_time_a_in array in 6th order
 - some formatting to make it easier to read the stencils