### PR TITLE
fix uninitialized variables

### DIFF
--- a/src/moddrydeposition.f90
+++ b/src/moddrydeposition.f90
@@ -35,12 +35,12 @@ module moddrydeposition
   save
   public  :: initdrydep, drydep, exitdrydep
 
-  logical :: ldrydep           !< On/Off switch dry deposition
+  logical :: ldrydep = .false.         !< On/Off switch dry deposition
   real, allocatable :: depfield(:,:,:) !< deposition flux (i,j,sv) [ug * m / (g * s)]
   logical, dimension(100) :: ldeptracers = .false. !< List of switches determining which of the tracers to deposit
   integer  :: ndeptracers = 0  !< Number of tracers that deposits
   integer  :: iname 
-  real :: nh3_avg, so2_avg	!GT added to not have the valiables needed for the calculations of ccomp hardcoded
+  real :: nh3_avg = -1, so2_avg = -1	!GT added to not have the variables needed for the calculations of ccomp hardcoded
 
   private :: Rc, Rb, vd
 
@@ -108,7 +108,7 @@ subroutine initdrydep
   enddo
 
   ! --- Local pre-calculations and settings
-  if (ldrydep .and. ndeptracers == 0) then
+  if (ldrydep .and. ndeptracers == 0 .and. myid == 0) then
     write (*,*) "initdrydep: WARNING .. drydeposition switched on, but no tracers to deposit. &
       Continuing without deposition model"
   end if

--- a/src/modemisdata.f90
+++ b/src/modemisdata.f90
@@ -46,7 +46,7 @@ module modemisdata
               svskip   =  0, &     ! no. scalars to exclude for emission
               nemis    = 0         ! no. of emitted scalars  
   logical  :: l_scale = .false.    ! emission scaling switch
-  real, dimension(100) :: scalefactor
+  real, dimension(100) :: scalefactor = 1
 
   character(len = 6), dimension(100) :: & 
               emisnames = (/ ('      ', iname=1, 100) /) ! list with scalar names,

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -227,7 +227,7 @@ save
       type(boundary_type), dimension(5) :: boundary
       logical, dimension(5) :: lboundary = .false.
       logical, dimension(5) :: lperiodic =  (/.true., .true., .true., .true., .false./)
-      real(field_r) :: dxint=-1.,dyint=-1.,dzint=-1.,tauh=60.,taum=0.,tau=60.,lambda,lambdas=-1.,lambdas_x=-1.,lambdas_y=-1.,lambdas_z=-1.,dxturb=-1.,dyturb=-1.
+      real(field_r) :: dxint=-1.,dyint=-1.,dzint=-1.,tauh=60.,taum=0.,tau=60.,lambda=-1,lambdas=-1.,lambdas_x=-1.,lambdas_y=-1.,lambdas_z=-1.,dxturb=-1.,dyturb=-1.
       integer :: nmodes=100,ntboundary=1,pbc = 3,iturb=0
       real,dimension(:),allocatable :: tboundary
 
@@ -261,8 +261,6 @@ save
 
       logical :: leq      = .true.  !<  switch for (non)-equidistant mode.
       logical :: lmomsubs = .false.  !<  switch to apply subsidence on the momentum or not
-
-      logical :: is_starting = .true. !< flag for knowing if a routine is called during startup
 
       character(80) :: author='', version='DALES 4.4.2'
 contains

--- a/src/modlsm.f90
+++ b/src/modlsm.f90
@@ -36,8 +36,8 @@ module modlsm
     integer, parameter :: iinterp_max   = 4  ! val = max(a,b)
 
     ! Soil grid
-    integer :: kmax_soil
-    real :: z_size_soil
+    integer :: kmax_soil = -1
+    real :: z_size_soil = -1
     real, allocatable :: z_soil(:), zh_soil(:)
     real, allocatable :: dz_soil(:), dzh_soil(:)
     real, allocatable :: dzi_soil(:), dzhi_soil(:)

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -82,8 +82,12 @@ contains
     allocate(pvp(2-ih:i1+ih,2-jh:j1+jh,kmax))
     allocate(pwp(2-ih:i1+ih,2-jh:j1+jh,k1))
 
+    pup = 0 ! these fields use only one halo cell but are exchanged with ih,jh halo cells
+    pvp = 0 ! initialize now to not have uninitialized data in the unused halo cells
+
     allocate(a(kmax), b(kmax), c(kmax))
-    !$acc enter data create(pup, pvp, pwp, a, b, c)
+    !$acc enter data copyin(pup, pvp)
+    !$acc enter data create(pwp, a, b, c)
 
   end subroutine initpois
 

--- a/src/modsurfdata.f90
+++ b/src/modsurfdata.f90
@@ -57,16 +57,16 @@ SAVE
   real, allocatable :: phiw    (:,:,:)    !<  Water content soil matrix [-]
   real, allocatable :: phiwm   (:,:,:)    !<  Water content soil matrix previous time step [-]
   real, allocatable :: phifrac (:,:,:)    !<  Relative water content per layer [-]
-  real              :: phiwav  (ksoilmax)
+  real              :: phiwav  (ksoilmax) = -1
   real, allocatable :: phitot  (:,:)      !<  Total soil water content [-]
   real, allocatable :: pCs     (:,:,:)    !<  Volumetric heat capacity [J/m3/K]
   real, allocatable :: rootf   (:,:,:)    !<  Root fraction per soil layer [-]
-  real              :: rootfav (ksoilmax)
+  real              :: rootfav (ksoilmax) = -1
   real, allocatable :: tsoil   (:,:,:)    !<  Soil temperature [K]
   real, allocatable :: tsoilm  (:,:,:)    !<  Soil temperature previous time step [K]
-  real              :: tsoilav (ksoilmax)
+  real              :: tsoilav (ksoilmax) = -1
   real, allocatable :: tsoildeep (:,:)    !<  Soil temperature [K]
-  real              :: tsoildeepav
+  real              :: tsoildeepav = -1
 
   real, allocatable :: swdavn  (:,:,:)
   real, allocatable :: swuavn  (:,:,:)
@@ -206,7 +206,7 @@ SAVE
   real              :: rssoilminav = -1
   real, allocatable :: tendskin (:,:)   !<  Tendency of skin [W/m2]
   real, allocatable :: gD       (:,:)   !<  Response factor vegetation to vapor pressure deficit [-]
-  real              :: gDav
+  real              :: gDav = -1
 
   ! Turbulent exchange variables
   logical           :: lmostlocal  = .false.  !<  Switch to apply MOST locally to get local Obukhov length

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -85,7 +85,7 @@ contains
 !! Calculate the liquid water content, do the microphysics, calculate the mean hydrostatic pressure,
 !! calculate the fields at the half levels, and finally calculate the virtual potential temperature.
   subroutine thermodynamics
-    use modglobal, only : lmoist,timee,k1,i1,j1,ih,jh,rd,rv,ijtot,cp,rlv,lnoclouds,lfast_thermo,is_starting
+    use modglobal, only : lmoist,timee,k1,i1,j1,ih,jh,rd,rv,ijtot,cp,rlv,lnoclouds,lfast_thermo
     use modfields, only : thl0, qt0, ql0, presf, exnf, thvh, thv0h, qt0av, ql0av, thvf, rhof
     use modmpi, only : slabsum, myid
     implicit none


### PR DESCRIPTION
...and:
move a timer_toc to the end of the routine in grwdamp, and remove unused variable is_starting.

The uninitialized values are mostly namelist options missing their default values.