### PR TITLE
Initialization from netCDF

### DIFF
--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -52,6 +52,7 @@ save
       integer(kind=longint) :: itrestart !<     * each trestart sec. a restart file is written to disk
       integer(kind=longint)    :: tnextrestart    !<     * each trestart sec. a restart file is written to disk
       character(50) :: startfile    !<    * name of the restart file
+      logical :: lstart_netcdf = .false.      !< Start from a NetCDF file
 
       logical :: llsadv   = .false. !<  switch for large scale forcings
       integer :: ntimedep = 100     !< maximum number of time points for time-dependent forcings

--- a/src/modnetcdf.f90
+++ b/src/modnetcdf.f90
@@ -37,12 +37,17 @@ contains
   !! the location of the error
   subroutine check(status, file, line)
 
+    use modmpi, only: myid
+
     integer,      intent(in) :: status, line
     character(*), intent(in) :: file
 
     if (status /= nf90_noerr) then
-      write(*,*) trim(nf90_strerror(status))
-      stop "NetCDF error in ", file, "on line ", line
+      if (myid == 0) then
+        write(*,*) "NetCDF error in: ", file, " on line: ", line
+        write(*,*) trim(nf90_strerror(status))
+      end if
+      stop
     end if
 
   end subroutine check

--- a/src/modnetcdf.f90
+++ b/src/modnetcdf.f90
@@ -1,0 +1,50 @@
+!> \file modnetcdf.f90
+!!  Convenience functions for working with NetCDF.
+!>
+!!  \author Caspar Jungbacker, Delft University of Technology
+!  This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+! Copyright 2024 Delft University of Technology
+!
+module modnetcdf
+
+  use netcdf
+
+  implicit none
+
+  private
+  
+  public :: check
+
+contains
+ 
+  !> Checks return code of netcdf calls
+  !!
+  !! If an error occurs, stops the program and print information about
+  !! the location of the error
+  subroutine check(status, file, line)
+
+    integer,      intent(in) :: status, line
+    character(*), intent(in) :: file
+
+    if (status /= nf90_noerr) then
+      write(*,*) trim(nf90_strerror(status))
+      stop "NetCDF error in ", file, "on line ", line
+    end if
+
+  end subroutine check
+
+end module modnetcdf

--- a/src/modnetcdf.f90
+++ b/src/modnetcdf.f90
@@ -25,7 +25,7 @@ module modnetcdf
 
   implicit none
 
-  private
+  public
   
   public :: check
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -535,7 +535,7 @@ contains
     integer isv, sdx
     logical negval !switch to allow or not negative values in randomnization
 
-    real, allocatable :: height(:), th0av(:)
+    real(field_r), allocatable :: height(:), th0av(:)
     real(field_r), allocatable :: thv0(:,:,:)
     integer, allocatable :: scalar_indices(:)
 
@@ -583,39 +583,43 @@ contains
 
           ps         = tb_ps(1)
 
+        else if (lstart_netcdf) then
+          call init_from_netcdf('init.'//cexpnr//'.nc', height(1:kmax), &
+                                uprof(1:kmax), vprof(1:kmax), thlprof(1:kmax), &
+                                qtprof(1:kmax), e12prof(1:kmax), &
+                                svprof(1:kmax,:), ug(1:kmax), vg(1:kmax), &
+                                wfls(1:kmax), dqtdxls(1:kmax), &
+                                dqtdyls(1:kmax), dqtdtls(1:kmax), &
+                                thlpcar(1:kmax), nsv, tracer_prop)
         else
-          if (lstart_netcdf) then
-            call read_prof_netcdf(height)
-          else
-            open (ifinput,file='prof.inp.'//cexpnr,status='old',iostat=ierr)
-            if (ierr /= 0) then
-               write(6,*) 'Cannot open the file ', 'prof.inp.'//cexpnr
-               STOP
-            end if
-            read (ifinput,'(a512)') chmess
-            write(*,     '(a512)') chmess
-            read (ifinput,'(a512)') chmess
+          open (ifinput,file='prof.inp.'//cexpnr,status='old',iostat=ierr)
+          if (ierr /= 0) then
+             write(6,*) 'Cannot open the file ', 'prof.inp.'//cexpnr
+             STOP
+          end if
+          read (ifinput,'(a512)') chmess
+          write(*,     '(a512)') chmess
+          read (ifinput,'(a512)') chmess
 
-            do k = 1, kmax
-              read (ifinput,*) &
+          do k = 1, kmax
+            read (ifinput,*) &
+                height (k), &
+                thlprof(k), &
+                qtprof (k), &
+                uprof  (k), &
+                vprof  (k), &
+                e12prof(k)
+          end do
+
+          close(ifinput)
+
+          open (ifinput, file='scalar.inp.'//cexpnr, status='old', iostat=ierr)
+          do k = 1, kmax
+            read (ifinput,*) &
                   height (k), &
-                  thlprof(k), &
-                  qtprof (k), &
-                  uprof  (k), &
-                  vprof  (k), &
-                  e12prof(k)
-            end do
-
-            close(ifinput)
-
-            open (ifinput, file='scalar.inp.'//cexpnr, status='old', iostat=ierr)
-            do k = 1, kmax
-              read (ifinput,*) &
-                    height (k), &
-                    (svprof (k,n),n=1,nsv)
-            end do
-            close(ifinput)
-          end if ! lstart_netcdf
+                  (svprof (k,n),n=1,nsv)
+          end do
+          close(ifinput)
         end if   !ltestbed
 
         write(*,*) 'height    thl      qt         u      v     e12'
@@ -989,7 +993,7 @@ contains
       else
 
         if (lstart_netcdf) then
-          call read_lscale_netcdf
+          continue ! Profiles have been read by init_from_netcdf
         else
           open (ifinput,file='lscale.inp.'//cexpnr, status='old',iostat=ierr)
           if (ierr /= 0) then

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1764,36 +1764,34 @@ contains
 
     real(field_r), intent(out) :: height(:) !< Vertical coordinates
 
-    integer :: ncid, grpid, varid, ierr !< NetCDF variables
+    integer :: ncid, varid, ierr !< NetCDF variables
     integer :: itrac                    !< Loop variable
 
     call check(nf90_open("init."//cexpnr//".nc", NF90_NOWRITE, ncid), __FILE__, __LINE__)
 
-    call check(nf90_inq_ncid(ncid, "init", grpid), __FILE__, __LINE__)
-
     ! "Regular" prognostic fields
-    call check(nf90_inq_varid(grpid, "u", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, uprof(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "u", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, uprof(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_inq_varid(grpid, "v", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, vprof(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "v", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, vprof(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_inq_varid(grpid, "thl", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, thlprof(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "thl", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, thlprof(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_inq_varid(grpid, "qt", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, qtprof(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "qt", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, qtprof(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_inq_varid(grpid, "e12", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, e12prof(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "e12", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, e12prof(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_inq_varid(grpid, "zf", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, height(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "zf", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, height(1:kmax)), __FILE__, __LINE__)
 
     ! Tracers
     do itrac = 1, nsv
       ! Search for the tracer
-      ierr = nf90_inq_varid(grpid, tracer_prop(itrac)%tracname, varid)
+      ierr = nf90_inq_varid(ncid, tracer_prop(itrac)%tracname, varid)
 
       ! If tracer is not found, don't stop but init with zeroes
       select case (ierr)

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -223,6 +223,7 @@ contains
     call D_MPI_BCAST(timeav_glob,1,0,commwrld,mpierr)
     call D_MPI_BCAST(nsv        ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(loutdirs   ,1,0,commwrld,mpierr)
+    call D_MPI_BCAST(lstart_netcdf,1,0,commwrld,mpierr)
 
     call D_MPI_BCAST(itot       ,1,0,commwrld,mpierr) ! DOMAIN
     call D_MPI_BCAST(jtot       ,1,0,commwrld,mpierr)

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1799,7 +1799,7 @@ contains
     integer :: ncid, varid, ierr
     integer :: itrac
 
-    call check(nf90_open(filename, NF90_NOWRITE, ncid), __FILE__, __LINE__)
+    call nchandle_error(nf90_open(filename, NF90_NOWRITE, ncid))
 
     ! "Regular" prognostic fields
     call read_nc_field(ncid, "u", uprof, fillvalue=0._field_r)
@@ -1824,7 +1824,7 @@ contains
     call read_nc_field(ncid, "dqtdtls", dqtdtls, fillvalue=0._field_r)
     call read_nc_field(ncid, "dthlrad", dthlrad, fillvalue=0._field_r)
 
-    call check(nf90_close(ncid), __FILE__, __LINE__)
+    call nchandle_error(nf90_close(ncid))
     
   end subroutine init_from_netcdf
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1755,17 +1755,44 @@ contains
   end subroutine baseprofs
 
   !> Read initial profiles from init.XXX.nc
-  subroutine init_from_netcdf(height)
+  !!
+  !! @param filename Path to the netCDF file to read from.
+  !! @param height Vertical levels.
+  !! @param uprof Initial eastward velocity profile.
+  !! @param vprof Initial northward velocity profile.
+  !! @param thlprof Initial liquid water potential temperature profile.
+  !! @param qtprof Initial total water mixing ratio profile.
+  !! @param e12prof Initial profile of the square root of the turbulence kinetic energy (TKE).
+  !! @param svprof Initiales profiles of scalars.
+  !! @param ug Geostrophic eastward wind.
+  !! @param vg Geostrophic northward wind.
+  !! @param wfls Large-scale subsidence.
+  !! @param dqtdxls Eastward gradient of the total water mixing ratio due to advection.
+  !! @param dqtdyls Northward gradient of the total water mixing ratio due to advection.
+  !! @param dqtdtls Tendency of the total water mixing ratio.
+  !! @param dthlrad Tendency of the liquid water potential temperature due to radiative heating.
+  subroutine init_from_netcdf(filename, height, uprof, vprof, thlprof, qtprof, &
+                              e12prof, svprof, ug, vg, wfls, dqtdxls, dqtdyls, &
+                              dqtdtls, dthlrad)
+                  
+    character(*),  intent(in)  :: filename
+    real(field_r), intent(out) :: height(:)
+    real(field_r), intent(out) :: uprof(:)
+    real(field_r), intent(out) :: vprof(:)
+    real(field_r), intent(out) :: thlprof(:)
+    real(field_r), intent(out) :: qtprof(:)
+    real(field_r), intent(out) :: e12prof(:)
+    real(field_r), intent(out) :: svprof(:,:)
+    real(field_r), intent(out) :: ug(:)
+    real(field_r), intent(out) :: vg(:)
+    real(field_r), intent(out) :: wfls(:)
+    real(field_r), intent(out) :: dqtdxls(:)
+    real(field_r), intent(out) :: dqtdyls(:)
+    real(field_r), intent(out) :: dqtdtls(:)
+    real(field_r), intent(out) :: dthlrad(:)
 
-    use modfields,  only: thlprof, qtprof, uprof, vprof, e12prof, svprof
-    use modglobal,  only: cexpnr, nsv, kmax
-    use modtracers, only: tracer_prop
-    use modnetcdf
-
-    real(field_r), intent(out) :: height(:) !< Vertical coordinates
-
-    integer :: ncid, varid, ierr !< NetCDF variables
-    integer :: itrac                    !< Loop variable
+    integer :: ncid, varid, ierr
+    integer :: itrac
 
     call check(nf90_open("init."//cexpnr//".nc", NF90_NOWRITE, ncid), __FILE__, __LINE__)
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1755,7 +1755,7 @@ contains
   end subroutine baseprofs
 
   !> Read initial profiles from init.XXX.nc
-  subroutine read_prof_netcdf(height)
+  subroutine init_from_netcdf(height)
 
     use modfields,  only: thlprof, qtprof, uprof, vprof, e12prof, svprof
     use modglobal,  only: cexpnr, nsv, kmax
@@ -1805,47 +1805,30 @@ contains
       end select
     end do
 
-    call check(nf90_close(ncid), __FILE__, __LINE__)
-    
-  end subroutine read_prof_netcdf
+    ! Large-scale forcings
+    call check(nf90_inq_varid(ncid, "ug", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, ug(1:kmax)), __FILE__, __LINE__)
 
-  !> Read large-scale forcings from init.XXX.nc
-  ! CJ: merge this with read_prof_netcdf?
-  subroutine read_lscale_netcdf
+    call check(nf90_inq_varid(ncid, "vg", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, vg(1:kmax)), __FILE__, __LINE__)
 
-    use modfields, only: ug, vg, wfls, dqtdxls, dqtdyls, dqtdtls, thlpcar
-    use modglobal, only: cexpnr, kmax
-    use modnetcdf
+    call check(nf90_inq_varid(ncid, "wfls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, wfls(1:kmax)), __FILE__, __LINE__)
 
-    integer :: ncid, grpid, varid
+    call check(nf90_inq_varid(ncid, "dqtdxls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, dqtdxls(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_open("init."//cexpnr//".nc", nf90_nowrite, ncid), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "dqtdyls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, dqtdyls(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_inq_ncid(ncid, "lscale", grpid), __FILE__, __LINE__)
-    
-    call check(nf90_inq_varid(grpid, "ug", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, ug(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "dqtdtls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, dqtdtls(1:kmax)), __FILE__, __LINE__)
 
-    call check(nf90_inq_varid(grpid, "vg", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, vg(1:kmax)), __FILE__, __LINE__)
-
-    call check(nf90_inq_varid(grpid, "wfls", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, wfls(1:kmax)), __FILE__, __LINE__)
-
-    call check(nf90_inq_varid(grpid, "dqtdxls", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, dqtdxls(1:kmax)), __FILE__, __LINE__)
-
-    call check(nf90_inq_varid(grpid, "dqtdyls", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, dqtdyls(1:kmax)), __FILE__, __LINE__)
-
-    call check(nf90_inq_varid(grpid, "dqtdtls", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, dqtdtls(1:kmax)), __FILE__, __LINE__)
-
-    call check(nf90_inq_varid(grpid, "dthlrad", varid), __FILE__, __LINE__)
-    call check(nf90_get_var(grpid, varid, thlpcar(1:kmax)), __FILE__, __LINE__)
+    call check(nf90_inq_varid(ncid, "dthlrad", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(ncid, varid, thlpcar(1:kmax)), __FILE__, __LINE__)
 
     call check(nf90_close(ncid), __FILE__, __LINE__)
-
-  end subroutine read_lscale_netcdf
+    
+  end subroutine init_from_netcdf
 
 end module modstartup

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -583,7 +583,7 @@ contains
 
         else
           if (lstart_netcdf) then
-            call read_init_netcdf(height)
+            call read_prof_netcdf(height)
           else
             open (ifinput,file='prof.inp.'//cexpnr,status='old',iostat=ierr)
             if (ierr /= 0) then
@@ -1751,7 +1751,7 @@ contains
   end subroutine baseprofs
 
   !> Read initial profiles from init.XXX.nc
-  subroutine read_init_netcdf(height)
+  subroutine read_prof_netcdf(height)
 
     use modfields,  only: thlprof, qtprof, uprof, vprof, e12prof, svprof
     use modglobal,  only: cexpnr, nsv, kmax
@@ -1805,6 +1805,6 @@ contains
 
     call check(nf90_close(ncid), __FILE__, __LINE__)
     
-  end subroutine read_init_netcdf
+  end subroutine read_prof_netcdf
 
 end module modstartup

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -539,7 +539,7 @@ contains
 
     character(len=512) :: chmess
     integer            :: status, nheader, ifield
-    integer, parameter :: maxcol = 30
+    integer, parameter :: maxcol = 50
     character(len=6)   :: headers(maxcol)
     !character(len=1)   :: sep
     character(len=6)   ::  header
@@ -986,25 +986,29 @@ contains
 
       else
 
-        open (ifinput,file='lscale.inp.'//cexpnr, status='old',iostat=ierr)
-        if (ierr /= 0) then
-           write(6,*) 'Cannot open the file ', 'lscale.inp.'//cexpnr
-           STOP
+        if (lstart_netcdf) then
+          call read_lscale_netcdf
+        else
+          open (ifinput,file='lscale.inp.'//cexpnr, status='old',iostat=ierr)
+          if (ierr /= 0) then
+             write(6,*) 'Cannot open the file ', 'lscale.inp.'//cexpnr
+             STOP
+          end if
+          read (ifinput,'(a80)') chmess
+          read (ifinput,'(a80)') chmess
+          do  k=1,kmax
+            read (ifinput,*) &
+                height (k), &
+                ug     (k), &
+                vg     (k), &
+                wfls   (k), &
+                dqtdxls(k), &
+                dqtdyls(k), &
+                dqtdtls(k), &
+                thlpcar(k)
+          end do
+          close(ifinput)
         end if
-        read (ifinput,'(a80)') chmess
-        read (ifinput,'(a80)') chmess
-        do  k=1,kmax
-          read (ifinput,*) &
-              height (k), &
-              ug     (k), &
-              vg     (k), &
-              wfls   (k), &
-              dqtdxls(k), &
-              dqtdyls(k), &
-              dqtdtls(k), &
-              thlpcar(k)
-        end do
-        close(ifinput)
 
       end if
 
@@ -1806,5 +1810,44 @@ contains
     call check(nf90_close(ncid), __FILE__, __LINE__)
     
   end subroutine read_prof_netcdf
+
+  !> Read large-scale forcings from init.XXX.nc
+  ! CJ: merge this with read_prof_netcdf?
+  subroutine read_lscale_netcdf
+
+    use modfields, only: ug, vg, wfls, dqtdxls, dqtdyls, dqtdtls, thlpcar
+    use modglobal, only: cexpnr, kmax
+    use modnetcdf
+
+    integer :: ncid, grpid, varid
+
+    call check(nf90_open("init."//cexpnr//".nc", nf90_nowrite, ncid), __FILE__, __LINE__)
+
+    call check(nf90_inq_ncid(ncid, "lscale", grpid), __FILE__, __LINE__)
+    
+    call check(nf90_inq_varid(grpid, "ug", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(grpid, varid, ug(1:kmax)), __FILE__, __LINE__)
+
+    call check(nf90_inq_varid(grpid, "vg", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(grpid, varid, vg(1:kmax)), __FILE__, __LINE__)
+
+    call check(nf90_inq_varid(grpid, "wfls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(grpid, varid, wfls(1:kmax)), __FILE__, __LINE__)
+
+    call check(nf90_inq_varid(grpid, "dqtdxls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(grpid, varid, dqtdxls(1:kmax)), __FILE__, __LINE__)
+
+    call check(nf90_inq_varid(grpid, "dqtdyls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(grpid, varid, dqtdyls(1:kmax)), __FILE__, __LINE__)
+
+    call check(nf90_inq_varid(grpid, "dqtdtls", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(grpid, varid, dqtdtls(1:kmax)), __FILE__, __LINE__)
+
+    call check(nf90_inq_varid(grpid, "dthlrad", varid), __FILE__, __LINE__)
+    call check(nf90_get_var(grpid, varid, thlpcar(1:kmax)), __FILE__, __LINE__)
+
+    call check(nf90_close(ncid), __FILE__, __LINE__)
+
+  end subroutine read_lscale_netcdf
 
 end module modstartup


### PR DESCRIPTION
As the name suggests, this PR introduces the functionality of performing cold starts from netCDF input. The variable names are a bit different from the old ASCII files, as they now follow the DALES convention.

Added a new subroutine in `modstat_nc` for reading a field (1D for now) from a netCDF file by providing the name of the variable. Essentially, it wraps `nf90_inq_varid` and `nf90_get_var`. Additionally, one can provide a default value to fill the array with in case the variable is not found.