### PR TITLE
modthermodynamics: fill in thv0h up to k1 also when lmoist=.false.

### DIFF
--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -265,10 +265,18 @@ contains
 
     else
       !$acc parallel loop collapse(3) default(present)
-      do k = 2, kmax
+      do k = 2, k1
         do j = 2, j1
           do i = 2, i1
             thv0h(i,j,k)  = thl0h(i,j,k)
+          end do
+        end do
+      end do
+
+      !$acc parallel loop collapse(3) default(present)
+      do k = 2, kmax
+        do j = 2, j1
+          do i = 2, i1
             dthvdz(i,j,k) = (thl0(i,j,k+1)-thl0(i,j,k-1))/(dzh(k+1)+dzh(k))
           end do
         end do


### PR DESCRIPTION
With open boundaries, thv0h is needed at k1, it was not calculated at k1 when lmoist=.false.