### PR TITLE
GABLS case: fix namoptions, add warning for uninitialized thls

### DIFF
--- a/cases/gabls1/namoptions.001
+++ b/cases/gabls1/namoptions.001
@@ -36,6 +36,7 @@ lcoriol    =  .true.
 z0         =  0.1
 ps         =  100000.00
 isurf      =  2
+thls       = 265 ! time-dependent, needed here for base profile setup
 /
 
 &DYNAMICS
@@ -53,6 +54,7 @@ iadv_sv     =  52
 
 &NAMSUBGRID
   lmason = .true.
+  ldelta = .true. ! lmason requires ldelta
   cf = 2.0
 /
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1551,6 +1551,9 @@ contains
         ibas_prf = 5
         print *, 'WARNING: warm start requires input files for density. ibas_prf defaulted to 5'
       endif
+      if(ibas_prf <= 3 .and. thls < 0) then
+         STOP 'thls has not been initialized but is needed for setting up the base profiles.'
+      end if
 
       if(ibas_prf==1) then !thv constant and hydrostatic balance
         thvb=thls*(1+(rv/rd-1)*qts) ! using thls, q_l assumed to be 0 during first time step


### PR DESCRIPTION
Fix GABLS flags. It uses the Mason subgrid scheme, which requires the ldelta flag too - Mason and Deardorff cannot be used at the same time.
  ldelta = .true.  ! lmason requires ldelta
Add thls to namoptions. The surface temperature is time-dependent, thls is still needed in namoptions to initialize the base profile.

Add a warning when initializing base profile if thls is not initialized.