### PR TITLE
Enable fast thermodynamics by default

### DIFF
--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -148,7 +148,7 @@ save
 
       logical :: lmoist   = .true.  !<   switch to calculate moisture fields
       logical :: lnoclouds = .false. !<   switch to enable/disable thl calculations
-      logical :: lfast_thermo = .false. !<   switch to enable faster icethermo scheme
+      logical :: lfast_thermo = .true. !<   switch to enable faster icethermo scheme
       logical :: lsgbucorr= .false.  !<   switch to enable subgrid buoyancy flux
       logical :: lconstexner = .false.  !<  switch to use the initial pressure profile in the exner function
 


### PR DESCRIPTION
Fast `icethermo` routines should give provide similar results as the old routines, but vectorize much better.