### PR TITLE
modradrrtmg: merge duplicate definitions of orbital parameters

### DIFF
--- a/src/modraddata.f90
+++ b/src/modraddata.f90
@@ -155,12 +155,14 @@ SAVE
                                                      ssaaersw, &
                                                      asmaersw, &
                                                      ecaersw
-  real(SHR_KIND_R4)                             :: eccen,     &  ! Eccentricity
-                                                   obliqr,    &  ! Earths obliquity in radians
-                                                   lambm0,    &  ! Mean long of perihelion at the vernal equinox (radians)
-                                                   mvelpp,    &  ! moving vernal equinox longitude of perihelion plus pi (radians)
-                                                   delta,     &  ! Solar declination angle in rad
-                                                   eccf          ! Earth-sun distance factor (ie. (1/r)**2)
+  real(SHR_KIND_R4) :: eccen,   &  ! Earth's eccentricity factor (unitless) (typically 0 to 0.1)
+                       obliq,   &  ! Earth's obliquity angle (deg) (-90 to +90) (typically 22-26)
+                       obliqr,  &  ! Earths obliquity in radians
+                       lambm0,  &  ! Mean long of perihelion at the vernal equinox (radians)
+                       mvelp,   &  ! Earth's moving vernal equinox at perhelion (deg)(0 to 360.0)
+                       mvelpp,  &  ! moving vernal equinox longitude of perihelion plus pi (radians) 
+                       delta,   &  ! Solar declination angle in rad
+                       eccf        ! Earth-sun distance factor (ie. (1/r)**2)
 
   real,parameter :: mwdry = 28.966, &
                     mwh2o = 18.016, &

--- a/src/modradrrtmg.f90
+++ b/src/modradrrtmg.f90
@@ -25,16 +25,6 @@ contains
     integer                :: npatch    ! Sounding levels above domain
     integer                :: i,j,k,ierr(4)
     logical                :: sunUp
-    real(SHR_KIND_R4),save ::  eccen, & ! Earth's eccentricity factor (unitless) (typically 0 to 0.1)
-                               obliq, & ! Earth's obliquity angle (deg) (-90 to +90) (typically 22-26)
-                               mvelp, & ! Earth's moving vernal equinox at perhelion (deg)(0 to 360.0)
-                               !
-                               ! Orbital information after processed by orbit_params
-                               !
-                               obliqr, &  ! Earth's obliquity in radians
-                               lambm0, &  ! Mean longitude of perihelion at the vernal equinox (radians)
-                               mvelpp     ! Earth's moving vernal equinox longitude
-                                          ! of perihelion plus pi (radians)
 
     real                   :: thlpld,thlplu,thlpsd,thlpsu
     real(KIND=kind_rb)     :: cpdair


### PR DESCRIPTION
Some orbital parameters were defined both in modradrrtmg and modraddata. Moved all orbital parameters to modraddata, which is where shr_orb_decl() looks for them. This is to resolve use of undefined variables found on Fugaku (debug build). Note the orbit calculations aren't actually used anyway.