### PR TITLE
Refactor CMake

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: ["gnu", "intel"]
-        hypre:   ["", "-DUSE_HYPRE=T"]
+        hypre:   ["On", "Off"]
         
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -53,8 +53,6 @@ jobs:
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
 
           sudo apt install -y intel-oneapi-mpi-devel intel-oneapi-compiler-fortran
-
-          echo "SYST=localpc_ifx" >> $GITHUB_ENV 
 
       - name: Checkout NetCdf-Fortran for Intel
         if: matrix.toolchain == 'intel'
@@ -87,7 +85,7 @@ jobs:
           fi
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=DEBUG ${{ matrix.fftw }} ${{ matrix.hypre }} ../
+          cmake --preset=${{ matrix.toolchain }} -DCMAKE_BUILD_TYPE=DEBUG -DENABLE_HYPRE=${{ matrix.hypre }} ../
 
       - name : Build
         run: |

--- a/.github/workflows/precision.yml
+++ b/.github/workflows/precision.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hypre:    ["", "-DUSE_HYPRE=T"]
-        field_r: ["32","64"]
-        pois_r:  ["32","64"]
+        hypre:    ["On", "Off"]
+        sp_fields: ["On","Off"]
+        sp_pois:  ["On","Off"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -39,11 +39,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=DEBUG \
-           ${{ matrix.fftw }} \
-           ${{ matrix.hypre }} \
-           -DPOIS_PRECISION=${{ matrix.pois_r }} \
-           -DFIELD_PRECISION=${{ matrix.field_r }} ../
+          cmake --preset=gnu \
+            -DENABLE_HYPRE=${{ matrix.hypre }} \
+            -DENABLE_FP32_FIELDS=${{ matrix.sp_fields }} \
+            -DENABLE_FP32_POIS=${{ matrix.sp_pois }} \
       - name : Build
         run: |
           cd build

--- a/.github/workflows/precision.yml
+++ b/.github/workflows/precision.yml
@@ -43,6 +43,7 @@ jobs:
             -DENABLE_HYPRE=${{ matrix.hypre }} \
             -DENABLE_FP32_FIELDS=${{ matrix.sp_fields }} \
             -DENABLE_FP32_POIS=${{ matrix.sp_pois }} \
+            ../
       - name : Build
         run: |
           cd build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,6 @@ jobs:
           
       - name: Run tests
         run: |
-          export DALES=~/build/bin/dales
+          export DALES=/home/runner/work/dales/dales/build/bin/dales
           pytest -rf --assert=plain --case=${{ matrix.case }}
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=DEBUG -DUSE_FFTW=True ..
+          cmake --preset=gnu -DCMAKE_BUILD_TYPE=Debug ../
 
       - name: Build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,6 @@ jobs:
           
       - name: Run tests
         run: |
-          export DALES=$(find ~+/build/src -maxdepth 1 -name "dales*")
+          export DALES=~/build/bin/dales
           pytest -rf --assert=plain --case=${{ matrix.case }}
           

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,7 @@
 [submodule "src/RTE-RRTMGP"]
 	path = src/RTE-RRTMGP
 	url = https://github.com/earth-system-radiation/rte-rrtmgp.git
+[submodule "external/ecbuild"]
+	path = external/ecbuild
+	url = https://github.com/ecmwf/ecbuild.git
+	branch = develop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project( DALES VERSION 5.0.0 LANGUAGES Fortran )
 ecbuild_add_option( FEATURE FFTW
                     DESCRIPTION "Build with FFTW"
                     DEFAULT ON
-                    REQUIRED_PACKAGES "NAME FFTW" )
+                    REQUIRED_PACKAGES "NAME FFTW COMPONENTS single double" )
 
 ecbuild_add_option( FEATURE HYPRE
                     DESCRIPTION "Build with HYPRE"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ add_compile_definitions( POIS_PRECISION=${POIS_PRECISION} )
 
 # Additional options
 
+if( ENABLE_FFTW )
+  add_compile_definitions( USE_FFTW )
+endif()
 if( ENABLE_NVTX )
   ecbuild_add_fortran_flags( -lnvToolsExt )
   add_compile_definitions( USE_NVTX )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,12 @@ ecbuild_add_option( FEATURE FP32_POIS
                     DESCRIPTION "Use single precision for Poisson solver"
                     DEFAULT OFF )
 
-ecbuild_add_option( FEATURE NVTX 
+ecbuild_add_option( FEATURE NVTX
                     DESCRIPTION "Enable NVTX profiling (only available when using NVIDIA compiler)"
                     CONDITION "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NVHPC"
                     DEFAULT OFF )
 
-ecbuild_add_option( FEATURE DALESLIB 
+ecbuild_add_option( FEATURE DALESLIB
                     DESCRIPTION "Build DALES libraries for use with OMUSE"
                     DEFAULT OFF )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,295 +1,67 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required( VERSION 3.17 FATAL_ERROR )
 
-### Choose CMAKE Type
-if(NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE RELEASE CACHE STRING
-      "Choose the type of build, options are: None Debug Release."
-      FORCE)
-endif()
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/external/ecbuild/cmake" )
+find_package( ecbuild REQUIRED )
 
-### Set compiler flags
-if("$ENV{SYST}" STREQUAL "localpc_ifort")
-  set(CMAKE_Fortran_COMPILER "mpiifort")
-  set(CMAKE_Fortran_FLAGS "-cpp -r8 -ftz" CACHE STRING "")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O3" CACHE STRING "")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-traceback -fpe1 -O0 -g -check all" CACHE STRING "")
-elseif("$ENV{SYST}" STREQUAL "localpc_ifx")
-  set(CMAKE_Fortran_COMPILER "mpiifx")
-  set(CMAKE_Fortran_FLAGS "-cpp -r8 -ftz" CACHE STRING "")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-O3" CACHE STRING "")
-  set(CMAKE_Fortran_FLAGS_DEBUG "-traceback -fpe1 -O0 -g -check all" CACHE STRING "")
-elseif("$ENV{SYST}" STREQUAL "FEDORA")
-  set(CMAKE_Fortran_COMPILER "mpif90")
-  set(CMAKE_Fortran_FLAGS "-cpp -fdefault-real-8 -fdefault-double-8 -march=native -malign-double -ffree-line-length-none -I /usr/lib64/gfortran/modules/mpich/ -std=gnu -Werror=implicit-interface" CACHE STRING "")
-  set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -O3" CACHE STRING "")
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
-  set (CMAKE_Fortran_FLAGS_DEV     "-fbounds-check -fbacktrace -fno-f2c -O3 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
- elseif("$ENV{SYST}" STREQUAL "gnu-fast")
-  set(CMAKE_Fortran_COMPILER "mpif90")
-  set(CMAKE_Fortran_FLAGS "-cpp -W -Wall -Wno-tabs -Wno-compare-reals -fdefault-real-8 -fdefault-double-8 -march=native -ffree-line-length-none -std=gnu -Werror=implicit-interface" CACHE STRING "")
-  set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -Ofast -g -fbacktrace" CACHE STRING "")
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
-elseif("$ENV{SYST}" STREQUAL "FX-Fujitsu")
-   set(CMAKE_Fortran_COMPILER "mpifrtpx")
-   set(CMAKE_Fortran_FLAGS "-Cpp -CcdRR8 -g -Koptmsg=2" CACHE STRING "")
-   set (CMAKE_Fortran_FLAGS_RELEASE "-Kfast -x 128" CACHE STRING "")
-   set (CMAKE_Fortran_FLAGS_DEBUG   "-Haefosux -O0" CACHE STRING "")
-   # Fujitsu fortran compiler
-   # -CcdRR8 default real is 64 bit, like gnu -fdefault-real-8
-   # -Ad (-CcR4R8) is like gnu -freal-4-real-8  ALL reals are 64 bit
-   # -Kfast optimization and SVE vectorization
-   # -Haefosux checking: s-subscript range, u-undefinied values
-   #                     a-argument mismatches, e-shape conformance
-   #                     f-simultaneousOPEN and I/O recursive calls
-   #                     o-overlapping dummy arguments and extend undefined
-   #                     x-module, submodule, common, and pointer undefined
-   # -x <n> inlines functions if the size increases by at most n bytes
-   #        128 gives good speedup
-   # -Koptmsg=2 prints a lot of optimization information
-   #
+project( DALES VERSION 5.0.0 LANGUAGES Fortran )
 
-# nVidia Fortran compiler
-elseif("$ENV{SYST}" STREQUAL "NV-OpenACC")
-    set(CMAKE_Fortran_COMPILER "mpif90")
-    set(CMAKE_Fortran_FLAGS "-W -Wall -Wno-tabs -Wno-compare-reals -acc=gpu,host -cuda -Minfo=accel -gpu=cc80,fastmath -Mpreprocess -Mr8 -Mfree -Werror" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_RELEASE "-Munroll -O3 -g -traceback" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-Minit-real=snan -traceback -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
-    add_compile_definitions(DALES_GPU)
-elseif("$ENV{SYST}" STREQUAL "NV-OpenACC-H100")
-    set(CMAKE_Fortran_COMPILER "mpif90")
-    set(CMAKE_Fortran_FLAGS "-W -Wall -Wno-tabs -Wno-compare-reals -acc=gpu,host -cuda -Minfo=accel -gpu=cc90,fastmath -Mpreprocess -Mr8 -Mfree -Werror" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_RELEASE "-Munroll -O3 -g -traceback" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-Minit-real=snan -traceback -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
-    add_compile_definitions(DALES_GPU)
-elseif("$ENV{SYST}" STREQUAL "NV-multicore")
-    set(CMAKE_Fortran_COMPILER "mpif90")
-    # Includes (temporary) flags for linking to nVidia-built NetCDF
-    set(CMAKE_Fortran_FLAGS "-W -Wall -Wno-tabs -Wno-compare-reals -acc=multicore -Minfo=accel -Mpreprocess -Mr8 -Mfree -Werror" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_RELEASE "-Munroll -Ofast -g -traceback" CACHE STRING "")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-Minit-real=snan -traceback -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
-elseif("$ENV{SYST}" STREQUAL "NO_OVERRIDES")
-   # don't set any compilation flags here, allows setting them outside CMake
+# Options
+
+ecbuild_add_option( FEATURE FFTW
+                    DESCRIPTION "Build with FFTW"
+                    DEFAULT ON
+                    REQUIRED_PACKAGES "NAME FFTW" )
+
+ecbuild_add_option( FEATURE HYPRE
+                    DESCRIPTION "Build with HYPRE"
+                    DEFAULT OFF
+                    REQUIRED_PACKAGES "NAME HYPRE" )
+
+ecbuild_add_option( FEATURE FP32_FIELDS
+                    DESCRIPTION "Use single precision for fields"
+                    DEFAULT OFF )
+
+ecbuild_add_option( FEATURE FP32_POIS
+                    DESCRIPTION "Use single precision for Poisson solver"
+                    DEFAULT OFF )
+
+ecbuild_add_option( FEATURE NVTX 
+                    DESCRIPTION "Enable NVTX profiling (only available when using NVIDIA compiler)"
+                    CONDITION "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NVHPC"
+                    DEFAULT OFF )
+
+ecbuild_add_option( FEATURE DALESLIB 
+                    DESCRIPTION "Build DALES libraries for use with OMUSE"
+                    DEFAULT OFF )
+
+# Check for required dependencies
+
+ecbuild_find_package( NetCDF REQUIRED COMPONENTS Fortran )
+ecbuild_find_mpi( COMPONENTS Fortran REQUIRED )
+
+# Set precision
+
+if( ENABLE_FP32_FIELDS )
+  set ( FIELD_PRECISION 32 )
 else()
-  set(CMAKE_Fortran_COMPILER "mpif90")
-  set(CMAKE_Fortran_FLAGS "-cpp -fimplicit-none -fdefault-real-8 -fdefault-double-8 -march=native -ffree-line-length-none -std=gnu -Werror=implicit-interface" CACHE STRING "")
-  set (CMAKE_Fortran_FLAGS_RELEASE "-funroll-all-loops -fno-f2c -O3" CACHE STRING "")
-  set (CMAKE_Fortran_FLAGS_DEBUG   "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" CACHE STRING "")
+  set ( FIELD_PRECISION 64 )
 endif()
 
-# On compiler options
-# June 2020: added -std=legacy to gfortran for compatibility with gfortran 10, which introduced stricter type checking
-# the old FFT code from Netlib/FFTPACK does not compile with gfortran 10 without this flag.
-# March 2021: fixed interfaces and removed -std=legacy
+add_compile_definitions( FIELD_PRECISION=${FIELD_PRECISION} )
 
-# For GCC based compilers:
-#  * -march=native   : compile for the current CPU, allows use of modern AVX etc.
-#  * -malign-double  : align stuff on 64-bit boundaries. Only for x86, e.g. not available on M1 macs. 
-#  * -finit-real-nan : makes the code slower, moved them to debug
-
-
-## Project parameters
-PROJECT(DALES Fortran)
-set(VERSION_MAJOR "4")
-set(VERSION_MINOR "4")
-set(VERSION_PATCH "2")
-
-# use nf-config to find paths to netcdf. Broken on Fedora due to module path missing.
-execute_process(COMMAND nf-config --prefix OUTPUT_VARIABLE NFCONFIG_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND nf-config --includedir OUTPUT_VARIABLE NFCONFIG_INCLUDE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-# execute_process(COMMAND nf-config --flibs OUTPUT_VARIABLE NFCONFIG_FORTRAN_LIB OUTPUT_STRIP_TRAILING_WHITESPACE)
-# not used at the moment - not just a path but several compiler flags
-
-### If necessary, resort to BASH-methods to find netcdf-directory
-#execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/findnetcdf OUTPUT_VARIABLE ADDMODULEPATH)
-
-### Find NetCDF files
-FIND_PATH(NETCDF_INCLUDE_DIR netcdf.mod NETCDF.mod
-  PATHS
-  ${NFCONFIG_INCLUDE_DIR}
-  $ENV{SARA_NETCDF_INCLUDE}
-  $ENV{SURFSARA_NETCDF_INCLUDE}
-  $ENV{NETCDF_INCLUDE}
-  ${ADDMODULEPATH}/include
-  /usr/include
-  $ENV{HOME}/include
-  /usr/lib64/gfortran/modules
-  DOC "NetCDF include directory (must contain netcdf.mod)"
-)
-
-FIND_LIBRARY(NETCDF_C_LIB netcdf
-  PATHS
-  $ENV{SARA_NETCDF_LIB}
-  $ENV{SURFSARA_NETCDF_LIB}
-  $ENV{NETCDF_LIB}
-  ${ADDMODULEPATH}/lib
-  ${ADDMODULEPATH}/lib64
-  /usr/lib
-  /usr/lib64
-  $ENV{HOME}/lib
-  $ENV{HOME}/lib64
-  DOC "NetCDF C library"
-)
-
-FIND_LIBRARY(NETCDF_FORTRAN_LIB netcdff
-  PATHS
-  ${NFCONFIG_PREFIX}/lib
-  $ENV{SARA_NETCDF_LIB}
-  $ENV{SURFSARA_NETCDF_LIB}
-  $ENV{NETCDF_LIB}
-  ${ADDMODULEPATH}/lib
-  ${ADDMODULEPATH}/lib64
-  /usr/lib
-  /usr/lib64
-  $ENV{HOME}/lib
-  $ENV{HOME}/lib64
-  DOC "NetCDF Fortran library"
-)
-
-# libHYPRE.a for static library
-FIND_LIBRARY(HYPRE_LIB HYPRE_core HYPRE
-  PATHS
-  $ENV{HYPRE_LIB}
-  ${ADDMODULEPATH}/lib
-  ${ADDMODULEPATH}/lib64
-  /usr/lib
-  /usr/lib64
-  $ENV{HOME}/lib
-  $ENV{HOME}/lib64
-  DOC "Iterative solver library"
-)
-
-FIND_PATH(FFTW_INCLUDE_DIR fftw3.f03
-  PATHS
-  $ENV{FFTW_INCLUDE_DIR}
-  /usr/include
-  DOC "FFTW include files (fftw3.f03)"
-)
-
-#libfftw3.a for static library
-FIND_LIBRARY(FFTW_LIB fftw3
-  PATHS
-  $ENV{FFTW_LIB}
-  /usr/lib
-  /usr/lib64
-  DOC "FFTW static library"
-)
-
-FIND_LIBRARY(FFTWF_LIB fftw3f
-  PATHS
-  $ENV{FFTW_LIB}
-  /usr/lib
-  /usr/lib64
-  DOC "FFTW single precision library"
-)
-
-#FIND_LIBRARY(NVTX_LIB nvToolsExt
-#  PATHS
-#  $ENV{NVTX_LIB}
-#  DOC "NVTX library"
-#)
-
-if(NETCDF_INCLUDE_DIR)
-  include_directories(${NETCDF_INCLUDE_DIR})
-else(NETCDF_INCLUDE_DIR)
-  MESSAGE(STATUS "WARNING: No NETCDF bindings are found.")
-endif(NETCDF_INCLUDE_DIR)
-
-if(FFTW_INCLUDE_DIR)
-  include_directories(${FFTW_INCLUDE_DIR})
-else(FFTW_INCLUDE_DIR)
-  MESSAGE(STATUS "WARNING: No FFTW3 bindings are found (fftw3.f03).")
-endif(FFTW_INCLUDE_DIR)
-
-if(NETCDF_C_LIB)
-  set(NETCDF_LIBS ${NETCDF_C_LIB})
-else(NETCDF_C_LIB)
-  MESSAGE(STATUS "WARNING: No NETCDF C bindings are found - may be OK.")
-endif(NETCDF_C_LIB)
-
-if(NETCDF_FORTRAN_LIB)
-  set(NETCDF_LIBS ${NETCDF_LIBS} ${NETCDF_FORTRAN_LIB})
-else(NETCDF_FORTRAN_LIB)
-  MESSAGE(STATUS "WARNING: No Fortran NETCDF bindings are found.")
-endif(NETCDF_FORTRAN_LIB)
-
-### Iterative solver (HYPRE)
-OPTION(USE_HYPRE "Also build iterative solver (optional, needs HYPRE)" OFF)
-
-### FFTW based poisson solver (FFTW)
-OPTION(USE_FFTW "Also build FFTW based poisson solver (optional, needs FFTW3)" ON)
-
-### NVTX
-OPTION(USE_NVTX "Enable GPU profiling" OFF)
-
-### Documentation
-INCLUDE(FindDoxygen)
-if(DOXYGEN)
-    ADD_SUBDIRECTORY(utils/doc)
+if( ENABLE_FP32_POIS )
+  set ( POIS_PRECISION 32 )
 else()
-    MESSAGE(STATUS "WARNING: Doxygen not found - Reference manual will not be created")
+  set ( POIS_PRECISION 64 )
 endif()
 
-### Set case
-if(NOT CASE)
-  set (CASE standard CACHE STRING
-      "Set the case."
-      FORCE)
+add_compile_definitions( POIS_PRECISION=${POIS_PRECISION} )
+
+# Additional options
+
+if( ENABLE_NVTX )
+  ecbuild_add_fortran_flags( -lnvToolsExt )
+  add_compile_definitions( USE_NVTX )
 endif()
 
-### Add case specific file
-FILE(GLOB usrfile "${CMAKE_CURRENT_SOURCE_DIR}/cases/${CASE}/moduser.f90")
-if(usrfile STREQUAL "")
-  set(usrfile "${CMAKE_CURRENT_SOURCE_DIR}/cases/standard/moduser.f90")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${usrfile} ${CMAKE_CURRENT_SOURCE_DIR}/src/moduser.f90)
-MESSAGE(STATUS "Case " ${CASE} " uses " ${usrfile})
-
-#optional compilation flags
-set(opt_flags "")
-if(USE_HYPRE)
-  # Build the iterative Poisson solver
-  list(APPEND OPTIONAL_LIBS ${HYPRE_LIB})
-	set(opt_flags "${opt_flags} -DUSE_HYPRE")
-endif(USE_HYPRE)
-if(USE_FFTW)
-  # Build the FFTW-based Poisson solver
-  list(APPEND OPTIONAL_LIBS ${FFTW_LIB} ${FFTWF_LIB})
-	set(opt_flags "${opt_flags} -DUSE_FFTW")
-endif(USE_FFTW)
-
-# Find CUDA Toolkit and set flags
-if("$ENV{SYST}" STREQUAL "NV-OpenACC")
-  include(FindCUDAToolkit REQUIRED)
-  include_directories(${CUDAToolkit_INCLUDE_DIRS})
-  set(opt_flags "${opt_flags} -cudalib=cufft")
-  if(USE_NVTX)
-    set(opt_flags "${opt_flags} -DUSE_NVTX -lnvToolsExt")
-  endif(USE_NVTX)
-endif()
-
-if("$ENV{SYST}" STREQUAL "NV-OpenACC-H100")
-  include(FindCUDAToolkit REQUIRED)
-  include_directories(${CUDAToolkit_INCLUDE_DIRS})
-  set(opt_flags "${opt_flags} -cudalib=cufft")
-  if(USE_NVTX)
-    set(opt_flags "${opt_flags} -DUSE_NVTX -lnvToolsExt")
-  endif(USE_NVTX)
-endif()
-
-
-if("$ENV{SYST}" STREQUAL "NV-multicore")
-  include(FindCUDAToolkit REQUIRED)
-  include_directories(${CUDAToolkit_INCLUDE_DIRS})
-  set(opt_flags "${opt_flags} -cudalib=cufft")
-endif()
-
-
-### Precision 
-set(POIS_PRECISION 64 CACHE STRING  "Precision for poisson solver (default 64 bit) [32,64]")
-set(FIELD_PRECISION 64 CACHE STRING "Precision for fields in modfields.f90 (default 64 bit) [32, 64]")
-
-# Append all  flags
-set(opt_flags "${opt_flags} -DPOIS_PRECISION=${POIS_PRECISION} -DFIELD_PRECISION=${FIELD_PRECISION}")
-string(APPEND CMAKE_Fortran_FLAGS "${opt_flags}")
-
-ADD_SUBDIRECTORY(src)
+add_subdirectory( src )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,7 @@ ecbuild_add_option( FEATURE FFTW
 
 ecbuild_add_option( FEATURE HYPRE
                     DESCRIPTION "Build with HYPRE"
-                    DEFAULT OFF
-                    REQUIRED_PACKAGES "NAME HYPRE" )
+                    DEFAULT OFF )
 
 ecbuild_add_option( FEATURE FP32_FIELDS
                     DESCRIPTION "Use single precision for fields"
@@ -62,6 +61,14 @@ add_compile_definitions( POIS_PRECISION=${POIS_PRECISION} )
 if( ENABLE_FFTW )
   add_compile_definitions( USE_FFTW )
 endif()
+
+if( ENABLE_HYPRE )
+  # For some reason, ecbuild_find_package doesn't find HYPRE (on Mac, at least)
+  find_library( HYPRE_LIB HYPRE REQUIRED )
+  ecbuild_info( "Found HYPRE: ${HYPRE_LIB}" )
+  add_compile_definitions( USE_HYPRE )
+endif()
+
 if( ENABLE_NVTX )
   ecbuild_add_fortran_flags( -lnvToolsExt )
   add_compile_definitions( USE_NVTX )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,60 @@
+{
+  "version": 9,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 17,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "gnu",
+      "displayName": "GNU toolchain",
+      "cacheVariables": {
+        "CMAKE_Fortran_COMPILER": "mpif90",
+        "CMAKE_Fortran_FLAGS": "-cpp -W -Wall -Wno-tabs -Wno-compare-reals -fdefault-real-8 -fdefault-double-8 -march=native -ffree-line-length-none -std=gnu -Werror=implicit-interface",
+        "CMAKE_Fortran_FLAGS_RELEASE": "-funroll-all-loops -fno-f2c -Ofast -g -fbacktrace",
+        "CMAKE_Fortran_FLAGS_DEBUG": "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow"
+      }
+    },
+    {
+      "name": "intel",
+      "displayName": "Intel toolchain",
+      "cacheVariables": {
+        "CMAKE_Fortran_COMPILER": "mpiifx",
+        "CMAKE_Fortran_FLAGS": "-cpp -r8 -ftz",
+        "CMAKE_Fortran_FLAGS_RELEASE": "-O3",
+        "CMAKE_Fortran_FLAGS_DEBUG": "-traceback -fpe1 -O0 -g -check all"
+      }
+    },
+    {
+      "name": "nvidia-cpu",
+      "displayName": "NVIDIA HPC SDK (CPU build)",
+      "cacheVariables": {
+        "CMAKE_Fortran_COMPILER": "mpif90",
+        "CMAKE_Fortran_FLAGS": "-Mpreprocess -Mr8 -Mfree",
+        "CMAKE_Fortran_FLAGS_RELEASE": "-Ofast",
+        "CMAKE_Fortran_FLAGS_DEBUG": "-traceback -fpe1 -O0 -g -check all"
+      }
+    },
+    {
+      "name": "nvidia-gpu",
+      "displayName": "NVIDIA HPC SDK (GPU build)",
+      "cacheVariables": {
+        "CMAKE_Fortran_COMPILER": "mpif90",
+        "CMAKE_Fortran_FLAGS": "-Mpreprocess -Mr8 -Mfree -acc=gpu,host -cuda -cudalib=cufft -gpu=cc60,cc70,cc80,cc90,fastmath -Minfo=accel",
+        "CMAKE_Fortran_FLAGS_RELEASE": "-Ofast",
+        "CMAKE_Fortran_FLAGS_DEBUG": "-traceback -fpe1 -O0 -g -check all"
+      }
+    },
+    {
+      "name": "fujitsu",
+      "displayName": "Fujitsu FX compiler",
+      "cacheVariables": {
+        "CMAKE_Fortran_COMPILER": "mpifrtpx",
+        "CMAKE_Fortran_FLAGS": "-Cpp -CcdRR8 -g -Koptmsg=2",
+        "CMAKE_Fortran_FLAGS_RELEASE": "-Kfast -x 128",
+        "CMAKE_Fortran_FLAGS_DEBUG": "-Haefosux -O0"
+      }
+    }
+  ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,46 +1,220 @@
-file(GLOB sourcefiles "*.f90" 
-	"RRTMG/RRTMG_LW/modules/*.f90"
-	"RRTMG/RRTMG_LW/src/*.f90"
-	"RRTMG/RRTMG_SW/modules/*.f90"
-	"RRTMG/RRTMG_SW/src/*.f90"
-	"RTE-RRTMGP/rte/*.F90"
-	"RTE-RRTMGP/rte/kernels-openacc/*.F90"
-	"RTE-RRTMGP/rte/kernels/mo_fluxes_broadband_kernels.F90"
-	"RTE-RRTMGP/rrtmgp/*.F90"
-	"RTE-RRTMGP/rrtmgp/kernels-openacc/*.F90"
-	"RTE-RRTMGP/extensions/cloud_optics/mo_cloud_optics.F90"
-	"RTE-RRTMGP/examples/mo_simple_netcdf.F90"
-	"RTE-RRTMGP/examples/mo_load_coefficients.F90"
-  "RTE-RRTMGP/examples/all-sky/mo_load_cloud_coefficients.F90")
+# DALES source files
+set( dales_srcs 
+	advec_2nd.f90
+	advec_5th.f90
+	advec_6th.f90
+	advec_hybrid.f90
+	advec_hybrid_f.f90
+	advec_kappa.f90
+	advec_upw.f90
+	bulkmicro_kk.f90
+	bulkmicro_sb.f90
+	daleslib.f90
+	fftnew.f90
+	go.f90
+	le_drydepos_gas_depac.f90
+	modAGScross.f90
+	modadvection.f90
+	modboundary.f90
+	modbudget.f90
+	modbulkmicro.f90
+	modbulkmicro3.f90
+	modbulkmicro3_column.f90
+	modbulkmicro3_point.f90
+	modbulkmicrostat.f90
+	modbulkmicrostat3.f90
+	modcanopy.f90
+	modcape.f90
+	modchecksim.f90
+	modchem.f90
+	modcloudfield.f90
+	modcrosssection.f90
+	modcufft.f90
+	moddatetime.f90
+	moddepcrosssection.f90
+	moddrydeposition.f90
+	modemisdata.f90
+	modemission.f90
+	modfft2d.f90
+	modfftw.f90
+	modfielddump.f90
+	modfields.f90
+	modforces.f90
+	modgenstat.f90
+	modglobal.f90
+	modgpu.f90
+	modgpumpiinterface.f90
+	modheterostats.f90
+	modhypre.f90
+	modlsm.f90
+	modlsmcrosssection.f90
+	modlsmstat.f90
+	modmicrodata.f90
+	modmicrodata3.f90
+	modmicrophysics.f90
+	modmpi.f90
+	modmpiinterface.f90
+	modmsebudg.f90
+	modnetcdf.f90
+	modnudge.f90
+	modnudgeboundary.f90
+	modnvtx.f90
+	modopenboundary.f90
+	modpois.f90
+	modprecision.f90
+	modquadrant.f90
+	modraddata.f90
+	modradfield.f90
+	modradfull.f90
+	modradiation.f90
+	modradrrtmg.f90
+	modradrte_rrtmgp.f90
+	modradstat.f90
+	modsampdata.f90
+	modsampling.f90
+	modsamptend.f90
+	modsimpleice.f90
+	modsimpleice2.f90
+	modsimpleicestat.f90
+	modstartup.f90
+	modstat_nc.f90
+	modstattend.f90
+	modsubgrid.f90
+	modsubgriddata.f90
+	modsurface.f90
+	modsurfdata.f90
+	modsynturb.f90
+	modtestbed.f90
+	modthermodynamics.f90
+	modtimedep.f90
+	modtimedepsv.f90
+	modtimer.f90
+	modtimestat.f90
+	modtmpfields.f90
+	modtracdata.f90
+	modtracer_type.f90
+	modtracers.f90
+	moduser.f90
+	modvarbudget.f90
+	program.f90
+	rad_rndnmb.f90
+	shr_orb_mod.f90
+	tstep.f90
+	utils.f90
+)
 
-# TODO: make more concise
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/test_transposes.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/mcica_random_numbers.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/mcica_subcol_gen_lw.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/mcica_subcol_gen_lw.1col.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/rrtmg_lw.1col.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/rrtmg_lw_cldprmc.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/rrtmg_lw_k_g.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/rrtmg_lw_rad.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/rrtmg_lw_rrtmc.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/mcica_random_numbers.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/mcica_subcol_gen_sw.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/mcica_subcol_gen_sw.1col.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/rrtmg_sw.1col.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/rrtmg_sw_cldprmc.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/rrtmg_sw_k_g.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/rrtmg_sw_rad.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/rrtmg_sw_spcvmc.f90)
-list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/modules/parkind.f90) # remove one parkind, RRTMG_LW has an identical one
+# RRTMG - longwave
+set( rrtmg_lw_srcs
+	RRTMG/RRTMG_LW/modules/parkind.f90
+	RRTMG/RRTMG_LW/modules/parrrtm.f90
+	RRTMG/RRTMG_LW/modules/rrlw_cld.f90
+	RRTMG/RRTMG_LW/modules/rrlw_con.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg01.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg02.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg03.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg04.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg05.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg06.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg07.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg08.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg09.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg10.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg11.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg12.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg13.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg14.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg15.f90
+	RRTMG/RRTMG_LW/modules/rrlw_kg16.f90
+	RRTMG/RRTMG_LW/modules/rrlw_ncpar.f90
+	RRTMG/RRTMG_LW/modules/rrlw_ref.f90
+	RRTMG/RRTMG_LW/modules/rrlw_tbl.f90
+	RRTMG/RRTMG_LW/modules/rrlw_vsn.f90
+	RRTMG/RRTMG_LW/modules/rrlw_wvn.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_cldprop.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_init.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_rad.nomcica.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_read_nc.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_rtrn.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_rtrnmc.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_rtrnmr.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_setcoef.f90
+	RRTMG/RRTMG_LW/src/rrtmg_lw_taumol.f90
+	RRTMG/RRTMG_LW/src/src_link
+	RRTMG/RRTMG_LW/src/util_link
+)
 
-# Still a hack and only works for GCC
-if(NOT ("$ENV{SYST}" STREQUAL "NV-OpenACC" OR "$ENV{SYST}" STREQUAL "NV-OpenACC-H100"))
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW/src/rrtmg_lw_init.f90 PROPERTIES COMPILE_FLAGS -Wno-error=implicit-interface)
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW/src/rrtmg_sw_init.f90 PROPERTIES COMPILE_FLAGS -Wno-error=implicit-interface)
+# RRTMG - shortwave
+set( rrtmg_sw_srcs 
+	RRTMG/RRTMG_SW/modules/parrrsw.f90
+	RRTMG/RRTMG_SW/modules/rrsw_aer.f90
+	RRTMG/RRTMG_SW/modules/rrsw_cld.f90
+	RRTMG/RRTMG_SW/modules/rrsw_con.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg16.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg17.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg18.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg19.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg20.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg21.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg22.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg23.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg24.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg25.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg26.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg27.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg28.f90
+	RRTMG/RRTMG_SW/modules/rrsw_kg29.f90
+	RRTMG/RRTMG_SW/modules/rrsw_ncpar.f90
+	RRTMG/RRTMG_SW/modules/rrsw_ref.f90
+	RRTMG/RRTMG_SW/modules/rrsw_tbl.f90
+	RRTMG/RRTMG_SW/modules/rrsw_vsn.f90
+	RRTMG/RRTMG_SW/modules/rrsw_wvn.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_cldprop.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_init.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_rad.nomcica.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_read_nc.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_reftra.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_setcoef.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_spcvrt.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_taumol.f90
+	RRTMG/RRTMG_SW/src/rrtmg_sw_vrtqdr.f90
+)
+
+# RTE-RRTMGP
+set( rrtmgp_srcs
+	# RTE
+	RTE-RRTMGP/rte/kernels-openacc/mo_optical_props_kernels.F90
+	RTE-RRTMGP/rte/kernels-openacc/mo_rte_solver_kernels.F90
+	RTE-RRTMGP/rte/kernels/mo_fluxes_broadband_kernels.F90
+	RTE-RRTMGP/rte/mo_fluxes.F90
+	RTE-RRTMGP/rte/mo_optical_props.F90
+	RTE-RRTMGP/rte/mo_rte_config.F90
+	RTE-RRTMGP/rte/mo_rte_kind.F90
+	RTE-RRTMGP/rte/mo_rte_lw.F90
+	RTE-RRTMGP/rte/mo_rte_sw.F90
+	RTE-RRTMGP/rte/mo_rte_util_array.F90
+	RTE-RRTMGP/rte/mo_source_functions.F90
+	# RRTMGP
+	RTE-RRTMGP/rrtmgp/kernels-openacc/mo_gas_optics_kernels.F90
+	RTE-RRTMGP/rrtmgp/mo_gas_concentrations.F90
+	RTE-RRTMGP/rrtmgp/mo_gas_optics.F90
+	RTE-RRTMGP/rrtmgp/mo_gas_optics_rrtmgp.F90
+	RTE-RRTMGP/rrtmgp/mo_rrtmgp_constants.F90
+	RTE-RRTMGP/rrtmgp/mo_rrtmgp_util_string.F90
+	# Cloud optics
+	RTE-RRTMGP/extensions/cloud_optics/mo_cloud_optics.F90
+	# Examples (why are these needed?)
+	RTE-RRTMGP/examples/all-sky/mo_load_cloud_coefficients.F90
+	RTE-RRTMGP/examples/mo_load_coefficients.F90
+	RTE-RRTMGP/examples/mo_simple_netcdf.F90
+)
+
+if( "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU" )
+	set_source_files_properties( ${rrtmg_lw_srcs} PROPERTIES COMPILE_FLAGS -Wno-error=implicit-interface )
+	set_source_files_properties( ${rrtmg_sw_srcs} PROPERTIES COMPILE_FLAGS -Wno-error=implicit-interface )
 endif()
 
 # Use git-version.cmake to create modversion.f90, containing a version string from git, e.g. "4.2-34-g62b85a-dirty"
-add_custom_target(tag_git_version ALL
+add_custom_target( tag_git_version ALL
   COMMAND ${CMAKE_COMMAND} -D TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/git-version.cmake
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
@@ -54,7 +228,12 @@ endif()
 
 # Stand-alone DALES program
 ecbuild_add_executable( TARGET dales.exe 
-												SOURCES ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
+												SOURCES 
+													${dales_srcs}
+													${rrtmg_lw_srcs}
+													${rrtmg_sw_srcs}
+													${rrtmgp_srcs}
+													${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
 												DEPENDS tag_git_version
 												INCLUDES 
 													${NETCDF_INCLUDE_DIR}
@@ -65,7 +244,12 @@ ecbuild_add_executable( TARGET dales.exe
 
 # DALES library, e.g. for use with OMUSE. Only built if -DENABLE_DALESLIB is turned on.
 ecbuild_add_library( TARGET libdales 
-										 SOURCES ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
+										 SOURCES
+												${dales_srcs}
+												${rrtmg_lw_srcs}
+												${rrtmg_sw_srcs}
+												${rrtmgp_srcs}
+												${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
 										 DEPENDS tag_git_version
 										 PUBLIC_INCLUDES 
 										   ${NETCDF_INCLUDE_DIR}
@@ -74,5 +258,3 @@ ecbuild_add_library( TARGET libdales
 										   NetCDF::NetCDF_Fortran
 											 $<$<BOOL:${ENABLE_FFTW}>:${fftw_lib}>
 										 CONDITION ENABLE_DALESLIB )
-
-install(TARGETS ${target_name} ${target_lib} DESTINATION ${CMAKE_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,6 +236,7 @@ ecbuild_add_executable( TARGET dales.exe
 													NetCDF::NetCDF_Fortran
 													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3> 
 													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f> )
+													$<$<BOOL:${ENABLE_HYPRE}>:${HYPRE_LIB}> )
 
 # DALES library, e.g. for use with OMUSE. Only built if -DENABLE_DALESLIB is turned on.
 ecbuild_add_library( TARGET libdales
@@ -253,4 +254,5 @@ ecbuild_add_library( TARGET libdales
 										   NetCDF::NetCDF_Fortran
 												$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3>
 												$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f>
+											 $<$<BOOL:${ENABLE_HYPRE}>:${HYPRE_LIB}>
 										 CONDITION ENABLE_DALESLIB )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,12 +220,6 @@ add_custom_target( tag_git_version ALL
   BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
 )
 
-# Choose the correct FFTW library
-if( ENABLE_FFTW )
-	set( pois_is_sp "$<BOOL:${ENABLE_FP32_POIS}>" )
-	set( fftw_lib "$<IF:${pois_is_sp},FFTW::fftw3f,FFTW::fftw3>" )
-endif()
-
 # Stand-alone DALES program
 ecbuild_add_executable( TARGET dales.exe 
 												SOURCES 
@@ -240,10 +234,11 @@ ecbuild_add_executable( TARGET dales.exe
 													$<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
 												LIBS 
 													NetCDF::NetCDF_Fortran
-													$<$<BOOL:${ENABLE_FFTW}>:${fftw_lib}> )
+													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3> 
+													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f> )
 
 # DALES library, e.g. for use with OMUSE. Only built if -DENABLE_DALESLIB is turned on.
-ecbuild_add_library( TARGET libdales 
+ecbuild_add_library( TARGET libdales
 										 SOURCES
 												${dales_srcs}
 												${rrtmg_lw_srcs}
@@ -251,10 +246,11 @@ ecbuild_add_library( TARGET libdales
 												${rrtmgp_srcs}
 												${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
 										 DEPENDS tag_git_version
-										 PUBLIC_INCLUDES 
+										 PUBLIC_INCLUDES
 										   ${NETCDF_INCLUDE_DIR}
 											 $<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
-										 PUBLIC_LIBS 
+										 PUBLIC_LIBS
 										   NetCDF::NetCDF_Fortran
-											 $<$<BOOL:${ENABLE_FFTW}>:${fftw_lib}>
+												$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3>
+												$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f>
 										 CONDITION ENABLE_DALESLIB )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # DALES source files
-set( dales_srcs 
+set( dales_srcs
 	advec_2nd.f90
 	advec_5th.f90
 	advec_6th.f90
@@ -144,7 +144,7 @@ set( rrtmg_lw_srcs
 )
 
 # RRTMG - shortwave
-set( rrtmg_sw_srcs 
+set( rrtmg_sw_srcs
 	RRTMG/RRTMG_SW/modules/parrrsw.f90
 	RRTMG/RRTMG_SW/modules/rrsw_aer.f90
 	RRTMG/RRTMG_SW/modules/rrsw_cld.f90
@@ -221,21 +221,21 @@ add_custom_target( tag_git_version ALL
 )
 
 # Stand-alone DALES program
-ecbuild_add_executable( TARGET dales.exe 
-												SOURCES 
+ecbuild_add_executable( TARGET dales.exe
+												SOURCES
 													${dales_srcs}
 													${rrtmg_lw_srcs}
 													${rrtmg_sw_srcs}
 													${rrtmgp_srcs}
-													${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
+													${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
 												DEPENDS tag_git_version
-												INCLUDES 
+												INCLUDES
 													${NETCDF_INCLUDE_DIR}
 													$<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
-												LIBS 
+												LIBS
 													NetCDF::NetCDF_Fortran
-													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3> 
-													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f> )
+													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3>
+													$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f>
 													$<$<BOOL:${ENABLE_HYPRE}>:${HYPRE_LIB}> )
 
 # DALES library, e.g. for use with OMUSE. Only built if -DENABLE_DALESLIB is turned on.
@@ -245,14 +245,14 @@ ecbuild_add_library( TARGET libdales
 												${rrtmg_lw_srcs}
 												${rrtmg_sw_srcs}
 												${rrtmgp_srcs}
-												${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
+												${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
 										 DEPENDS tag_git_version
 										 PUBLIC_INCLUDES
 										   ${NETCDF_INCLUDE_DIR}
 											 $<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
 										 PUBLIC_LIBS
 										   NetCDF::NetCDF_Fortran
-												$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3>
-												$<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f>
+											 $<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3>
+											 $<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f>
 											 $<$<BOOL:${ENABLE_HYPRE}>:${HYPRE_LIB}>
 										 CONDITION ENABLE_DALESLIB )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,4 @@
-# Add all Fortran90 files from this directory
-# This will also add some unwated files, which we will remove again below
-include_directories(
-	"${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW"
-	"${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW"
-	"${CMAKE_CURRENT_SOURCE_DIR}/RTE-RRTMGP/rte"
-)
-
-FILE(GLOB sourcefiles "*.f90" 
+file(GLOB sourcefiles "*.f90" 
 	"RRTMG/RRTMG_LW/modules/*.f90"
 	"RRTMG/RRTMG_LW/src/*.f90"
 	"RRTMG/RRTMG_SW/modules/*.f90"
@@ -54,19 +46,33 @@ add_custom_target(tag_git_version ALL
   BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
 )
 
+# Choose the correct FFTW library
+if( ENABLE_FFTW )
+	set( pois_is_sp "$<BOOL:${ENABLE_FP32_POIS}>" )
+	set( fftw_lib "$<IF:${pois_is_sp},FFTW::fftw3f,FFTW::fftw3>" )
+endif()
+
 # Stand-alone DALES program
 ecbuild_add_executable( TARGET dales.exe 
 												SOURCES ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
-												INCLUDES ${NETCDF_INCLUDE_DIR}
 												DEPENDS tag_git_version
-												LIBS NetCDF::NetCDF_Fortran)
+												INCLUDES 
+													${NETCDF_INCLUDE_DIR}
+													$<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
+												LIBS 
+													NetCDF::NetCDF_Fortran
+													$<$<BOOL:${ENABLE_FFTW}>:${fftw_lib}> )
 
 # DALES library, e.g. for use with OMUSE. Only built if -DENABLE_DALESLIB is turned on.
 ecbuild_add_library( TARGET libdales 
 										 SOURCES ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
-										 PUBLIC_INCLUDES ${NETCDF_INCLUDE_DIR}
-										 PUBLIC_LIBS NetCDF::NetCDF_Fortran
 										 DEPENDS tag_git_version
+										 PUBLIC_INCLUDES 
+										   ${NETCDF_INCLUDE_DIR}
+											 $<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
+										 PUBLIC_LIBS 
+										   NetCDF::NetCDF_Fortran
+											 $<$<BOOL:${ENABLE_FFTW}>:${fftw_lib}>
 										 CONDITION ENABLE_DALESLIB )
 
 install(TARGETS ${target_name} ${target_lib} DESTINATION ${CMAKE_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,11 @@
-set(target_name dales4.4)
-set(target_lib dales)
-
 # Add all Fortran90 files from this directory
 # This will also add some unwated files, which we will remove again below
+include_directories(
+	"${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_LW"
+	"${CMAKE_CURRENT_SOURCE_DIR}/RRTMG/RRTMG_SW"
+	"${CMAKE_CURRENT_SOURCE_DIR}/RTE-RRTMGP/rte"
+)
+
 FILE(GLOB sourcefiles "*.f90" 
 	"RRTMG/RRTMG_LW/modules/*.f90"
 	"RRTMG/RRTMG_LW/src/*.f90"
@@ -16,7 +19,7 @@ FILE(GLOB sourcefiles "*.f90"
 	"RTE-RRTMGP/extensions/cloud_optics/mo_cloud_optics.F90"
 	"RTE-RRTMGP/examples/mo_simple_netcdf.F90"
 	"RTE-RRTMGP/examples/mo_load_coefficients.F90"
-        "RTE-RRTMGP/examples/all-sky/mo_load_cloud_coefficients.F90")
+  "RTE-RRTMGP/examples/all-sky/mo_load_cloud_coefficients.F90")
 
 # TODO: make more concise
 list(REMOVE_ITEM sourcefiles ${CMAKE_CURRENT_SOURCE_DIR}/test_transposes.f90)
@@ -49,20 +52,21 @@ add_custom_target(tag_git_version ALL
   COMMAND ${CMAKE_COMMAND} -D TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/git-version.cmake
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
-  )
+)
 
 # Stand-alone DALES program
-add_executable(${target_name} ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90)
-target_link_libraries(${target_name} ${NETCDF_LIBS} ${OPTIONAL_LIBS})
-add_dependencies(${target_name} tag_git_version)
+ecbuild_add_executable( TARGET dales.exe 
+												SOURCES ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90 
+												INCLUDES ${NETCDF_INCLUDE_DIR}
+												DEPENDS tag_git_version
+												LIBS NetCDF::NetCDF_Fortran)
 
-# DALES library, e.g. for use with OMUSE
-add_library(${target_lib} ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90)
-add_dependencies(${target_lib} tag_git_version)
-
-# set separate module directories for the program and library targets, to avoid problems during parallel builds (make -j 8)
-set_target_properties(${target_name} PROPERTIES Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/program_modules")
-set_target_properties(${target_lib} PROPERTIES Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/library_modules")
-
+# DALES library, e.g. for use with OMUSE. Only built if -DENABLE_DALESLIB is turned on.
+ecbuild_add_library( TARGET libdales 
+										 SOURCES ${sourcefiles} ${CMAKE_CURRENT_BINARY_DIR}/modversion.f90
+										 PUBLIC_INCLUDES ${NETCDF_INCLUDE_DIR}
+										 PUBLIC_LIBS NetCDF::NetCDF_Fortran
+										 DEPENDS tag_git_version
+										 CONDITION ENABLE_DALESLIB )
 
 install(TARGETS ${target_name} ${target_lib} DESTINATION ${CMAKE_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,6 @@ set( dales_srcs
 	modtimedepsv.f90
 	modtimer.f90
 	modtimestat.f90
-	modtmpfields.f90
 	modtracdata.f90
 	modtracer_type.f90
 	modtracers.f90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,7 +220,7 @@ add_custom_target( tag_git_version ALL
 )
 
 # Stand-alone DALES program
-ecbuild_add_executable( TARGET dales.exe
+ecbuild_add_executable( TARGET dales
 												SOURCES
 													${dales_srcs}
 													${rrtmg_lw_srcs}


### PR DESCRIPTION
Clean up and refactor our CMake infrastructure, using ECMWF's [ecbuild](https://github.com/ecmwf/ecbuild) helper functions.

- Use CMake presets for toolchain selection. Instead of using the `SYST` environment variable, a toolchain can be selected by providing `--preset=<name>` to the `cmake` command. For example:
```
cmake --preset=gnu ..
```
is equal to the old workflow of setting `SYST=gnu-fast` before calling `cmake`. To get a list of all defined presets, execute:
```
cmake --list-presets
```

- Renamed some compilation options. I will provide an updated list of these in the documentation.
- Renamed the DALES executable from `dalesX.Y` to just `dales`. The DALES library has been renamed to `libdales`.
- Disabled compilation of the DALES library by default.
- Update minimum CMake version to 3.17.
- Updated CI.