### PR TITLE
modnudge:  fix ascii nudge, broadcast logicals

### DIFF
--- a/src/modnudge.f90
+++ b/src/modnudge.f90
@@ -251,6 +251,12 @@ contains
       lthlnudge = any(abs(thlnudge) > 1e-8)
       lqtnudge = any(abs(qtnudge) > 1e-8)
 
+      call D_MPI_BCAST(lunudge, 1, 0, comm3d, mpierr)
+      call D_MPI_BCAST(lvnudge, 1, 0, comm3d, mpierr)
+      call D_MPI_BCAST(lwnudge, 1, 0, comm3d, mpierr)
+      call D_MPI_BCAST(lthlnudge, 1, 0, comm3d, mpierr)
+      call D_MPI_BCAST(lqtnudge, 1, 0, comm3d, mpierr)
+
       tnudge = tnudgefac * tnudge
 
       tunudge(:,:) = tnudge(:,:)


### PR DESCRIPTION
for the old-style nudge the variables lunudge, lvnudge, ... must be broadcast after they have been determined from the profiles, since that is done ony on task 0. Otherwise hangs when some tasks do broadcasts later and others don't.