### PR TITLE
modmicrophysics: stop and warn if Nc_0 is unreasonably small

### DIFF
--- a/src/modmicrophysics.f90
+++ b/src/modmicrophysics.f90
@@ -66,7 +66,15 @@ contains
             ! Bulkmicro 3 special treatment of saturation adjustment is currently only impmemented in the fast_thermo scheme
          end if
       end if
-    end if
+
+      if (Nc_0 < 1e4) then
+         ! Check that Nc_0 is reasonable.
+         ! It's easy to give it in units of /cm3 by mistake,
+         ! and when run with RRTMG that results in a hard-to-understand crash
+         ! in the short-wave scheme
+         STOP 'Nc_0 is suspiciously small (unit should be number per m3).'
+      end if
+   end if
 
     call D_MPI_BCAST(imicro,   1, 0,comm3d,ierr)
     call D_MPI_BCAST(l_sb,     1, 0,comm3d,ierr)


### PR DESCRIPTION
The cloud droplet number concentration Nc_0 should be given in number per m3. Giving it in the common unit of number per cm3 results in a confusing and hard to track down error from RRTMG at dawn (ask me how I know):

LIQUID SSA GRTR THAN 1.0

This commit adds a stop with a warning, if Nc_0 < 1e6 at initialization,  which is a reasonably sure sign it was given in the wrong unit.

There is probably a bug in RRTMG as well - it says it accepts cloud droplet sizes up to 60 um, but a droplet > 59 um turns what should be an interpolation in a table into an extrapolation, and the extrapolated value exceeds the limit 1.0, which is checked for afterwards.