### PR TITLE
Add routines for masked slab averages

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,7 @@ set( dales_srcs
 	modsamptend.f90
 	modsimpleice.f90
 	modsimpleice2.f90
+	modslabaverage.f90
 	modstartup.f90
 	modstat_nc.f90
 	modstattend.f90

--- a/src/modslabaverage.f90
+++ b/src/modslabaverage.f90
@@ -236,7 +236,7 @@ contains
     if (present(local)) then
       do_global = .not. local
     else
-      do_global = .false.
+      do_global = .true.
     end if
 
     fillvalue_ = 0
@@ -333,7 +333,7 @@ contains
     if (present(local)) then
       do_global = .not. local
     else
-      do_global = .false.
+      do_global = .true.
     end if
 
     fillvalue_ = 0

--- a/src/modslabaverage.f90
+++ b/src/modslabaverage.f90
@@ -1,0 +1,315 @@
+! This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+! Copyright 1993-2025, The DALES Team.
+!
+
+!> Routines for computing (masked) slab averaged profiles.
+module modslabaverage
+
+  use modglobal, only: ijtot
+  use modmpi,    only: mpi_allreduce, mpi_in_place, mpi_real4, mpi_real8, mpi_integer, &
+                       mpi_sum, comm3d, mpierr
+
+  implicit none
+
+  private
+
+  character(len=*), parameter :: modname = 'modslabaverage'
+
+  public :: slabavg
+
+  interface slabavg
+    module procedure slabavg_r4
+    module procedure slabavg_r8
+    module procedure slabavg_r4_masked
+    module procedure slabavg_r8_masked
+  end interface slabavg
+
+contains
+
+  !> Compute slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r4(field, nh, avg, kstart, kend)
+
+    real(4), intent(in)  :: field(:,:,:)
+    integer, intent(in)  :: nh
+    real(4), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    real(4) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    !$acc parallel loop gang default(present)
+    do k = ks, ke
+      fld_sum = 0
+      !$acc loop vector collapse(2) reduction(+: fld_sum)
+      do j = js, je
+        do i = is, ie
+          fld_sum = fld_sum + field(i,j,k)
+        end do
+      end do
+      avg(k) = fld_sum / ijtot
+    end do
+
+    ! TODO: experiment with non-blocking allreduce
+    !$acc host_data use_device(avg)
+    call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real4, mpi_sum, &
+                       comm3d, mpierr)
+    !$acc end host_data
+
+  end subroutine slabavg_r4
+
+  !> Compute slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average.
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r8(field, nh, avg, kstart, kend)
+
+    real(8), intent(in)  :: field(:,:,:)
+    integer, intent(in)  :: nh
+    real(8), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    real(8) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    !$acc parallel loop gang default(present)
+    do k = ks, ke
+      fld_sum = 0
+      !$acc loop vector collapse(2) reduction(+: fld_sum)
+      do j = js, je
+        do i = is, ie
+          fld_sum = fld_sum + field(i,j,k)
+        end do
+      end do
+      avg(k) = fld_sum / ijtot
+    end do
+
+    !$acc host_data use_device(avg)
+    call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real8, mpi_sum, &
+                       comm3d, mpierr)
+    !$acc end host_data
+
+  end subroutine slabavg_r8
+
+  !> Compute masked slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param mask Mask to apply. Values marked as .TRUE. will be included in the average.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average.
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r4_masked(field, mask, nh, avg, kstart, kend)
+
+    real(4), intent(in)  :: field(:,:,:)
+    logical, intent(in)  :: mask(:,:,:)
+    integer, intent(in)  :: nh
+    real(4), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    integer :: test, n_cells
+    real(4) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    ! Use a block to place n_cells_tot on the stack
+    block
+      integer :: n_cells_tot(ks:ke)
+
+      !$acc data create(n_cells_tot)
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        fld_sum = 0
+        n_cells = 0
+        !$acc loop vector collapse(2) reduction(+: fld_sum, n_cells)
+        do j = js, je
+          do i = is, ie
+            test = merge(1, 0, mask(i,j,k))
+            fld_sum = fld_sum + test * field(i,j,k)
+            n_cells = n_cells + test
+          end do
+        end do
+        avg(k) = fld_sum
+        n_cells_tot(k) = n_cells
+      end do
+
+      !$acc host_data use_device(avg, ne)
+      call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real4, mpi_sum, &
+                         comm3d, mpierr)
+      call mpi_allreduce(mpi_in_place, n_cells_tot, ke - ks + 1, mpi_integer, mpi_sum, &
+                         comm3d, mpierr)
+      !$acc end host_data
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        avg(k) = avg(k) / n_cells_tot(k)
+      end do
+
+      !$acc end data
+
+    end block
+
+  end subroutine slabavg_r4_masked
+
+  !> Compute masked slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param mask Mask to apply. Values marked as .TRUE. will be included in the average.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average.
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r8_masked(field, mask, nh, avg, kstart, kend)
+    real(8), intent(in)  :: field(:,:,:)
+    logical, intent(in)  :: mask(:,:,:)
+    integer, intent(in)  :: nh
+    real(8), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    integer :: test, n_cells
+    real(8) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    ! Use a block to place n_cells_tot on the stack
+    block
+      integer :: n_cells_tot(ks:ke)
+
+      !$acc data create(n_cells_tot)
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        fld_sum = 0
+        n_cells = 0
+        !$acc loop vector collapse(2) reduction(+: fld_sum, n_cells)
+        do j = js, je
+          do i = is, ie
+            test = merge(1, 0, mask(i,j,k))
+            fld_sum = fld_sum + test * field(i,j,k)
+            n_cells = n_cells + test
+          end do
+        end do
+        avg(k) = fld_sum
+        n_cells_tot(k) = n_cells
+      end do
+
+      !$acc host_data use_device(avg, ne)
+      call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real4, mpi_sum, &
+              comm3d, mpierr)
+      call mpi_allreduce(mpi_in_place, n_cells_tot, ke - ks + 1, mpi_integer, mpi_sum, &
+              comm3d, mpierr)
+      !$acc end host_data
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        avg(k) = avg(k) / n_cells_tot(k)
+      end do
+
+      !$acc end data
+
+    end block
+
+  end subroutine slabavg_r8_masked
+
+end module modslabaverage

--- a/src/modslabaverage.f90
+++ b/src/modslabaverage.f90
@@ -197,7 +197,9 @@ contains
   !! \param kstart Lowest vertical level to average.
   !! \param kend Highest vertical level to average.
   !! \param local Only compute average on local MPI domain.
-  subroutine slabavg_r4_masked(field, mask, nh, avg, kstart, kend, local)
+  !! \param fillvalue Value to use for fully masked layers. Default is 0.
+  subroutine slabavg_r4_masked(field, mask, nh, avg, kstart, kend, local, &
+                               fillvalue)
 
     real(4), intent(in)  :: field(:,:,:)
     logical, intent(in)  :: mask(:,:,:)
@@ -206,12 +208,13 @@ contains
 
     integer, optional, intent(in) :: kstart, kend
     logical, optional, intent(in) :: local
+    real(4), optional, intent(in) :: fillvalue
 
     integer :: i, j, k
     integer :: is, ie, js, je, ks, ke
     integer :: test, n_cells
     logical :: do_global
-    real(4) :: fld_sum
+    real(4) :: fld_sum, fillvalue_
 
     is = lbound(field, dim=1) + nh
     ie = ubound(field, dim=1) - nh
@@ -235,6 +238,9 @@ contains
     else
       do_global = .false.
     end if
+
+    fillvalue_ = 0
+    if (present(fillvalue)) fillvalue_ = fillvalue
 
     ! Use a block to place n_cells_tot on the stack
     block
@@ -269,7 +275,7 @@ contains
 
       !$acc parallel loop gang default(present)
       do k = ks, ke
-        avg(k) = avg(k) / n_cells_tot(k)
+        avg(k) = merge(avg(k) / n_cells_tot(k), fillvalue_, n_cells_tot(k) > 0)
       end do
 
       !$acc end data
@@ -288,7 +294,10 @@ contains
   !! \param kstart Lowest vertical level to average.
   !! \param kend Highest vertical level to average.
   !! \param local Only compute average on local MPI domain.
-  subroutine slabavg_r8_masked(field, mask, nh, avg, kstart, kend, local)
+  !! \param fillvalue Value to use for fully masked layers. Default is 0.
+  subroutine slabavg_r8_masked(field, mask, nh, avg, kstart, kend, local, &
+                               fillvalue)
+
     real(8), intent(in)  :: field(:,:,:)
     logical, intent(in)  :: mask(:,:,:)
     integer, intent(in)  :: nh
@@ -296,12 +305,13 @@ contains
 
     integer, optional, intent(in) :: kstart, kend
     logical, optional, intent(in) :: local
+    real(8), optional, intent(in) :: fillvalue
 
     integer :: i, j, k
     integer :: is, ie, js, je, ks, ke
     integer :: test, n_cells
     logical :: do_global
-    real(8) :: fld_sum
+    real(8) :: fld_sum, fillvalue_
 
     is = lbound(field, dim=1) + nh
     ie = ubound(field, dim=1) - nh
@@ -325,6 +335,9 @@ contains
     else
       do_global = .false.
     end if
+
+    fillvalue_ = 0
+    if (present(fillvalue)) fillvalue_ = fillvalue
 
     ! Use a block to place n_cells_tot on the stack
     block
@@ -359,7 +372,7 @@ contains
 
       !$acc parallel loop gang default(present)
       do k = ks, ke
-        avg(k) = avg(k) / n_cells_tot(k)
+        avg(k) = merge(avg(k) / n_cells_tot(k), fillvalue_, n_cells_tot(k) > 0)
       end do
 
       !$acc end data


### PR DESCRIPTION
Added `modslabaverage.f90` which contains various subroutines for computing slab averages. The masked flavors are needed for the upcoming IBM module by Steven, and the tendency-sampling-system (or however you want to call it) that I'm working on for aerosols.

Some assumptions/choices I made in the process:
- Slab averages are always computed over the *entire* horizontal domain. I.e., from 2 to i1/j1.
- The number of ghost cells in x and y directions is always the same. This, and the assumption above, greatly simplifies the function signature. The upper and lower bounds for the loops can be inferred using the `lbound` and `ubound` intrinsics.
- Division by `ijtot` is moved inside the function. This division is not done in the old `slabsum`. Why would you not want to divide by `ijtot`?

To keep this PR small, I've not replaced any existing calls to `slabsum`. On the longer term, we can do this and remove the old ones, cleaning up the code some more.

@StevenvdLinden could you check if the masked versions do what you expect them to (at least semantically)?