### PR TITLE
New statistics module for profiles

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ set( dales_srcs
 	modslabaverage.f90
 	modstartup.f90
 	modstat_nc.f90
+	modstat_profiles.f90
 	modstattend.f90
 	modsubgrid.f90
 	modsubgriddata.f90

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,7 @@ set( dales_srcs
 	modsamptend.f90
 	modsimpleice.f90
 	modsimpleice2.f90
+	modslabaverage.f90
 	modstartup.f90
 	modstat_nc.f90
 	modstattend.f90

--- a/src/modslabaverage.f90
+++ b/src/modslabaverage.f90
@@ -1,0 +1,315 @@
+! This file is part of DALES.
+!
+! DALES is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! DALES is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+! Copyright 1993-2025, The DALES Team.
+!
+
+!> Routines for computing (masked) slab averaged profiles.
+module modslabaverage
+
+  use modglobal, only: ijtot
+  use modmpi,    only: mpi_allreduce, mpi_in_place, mpi_real4, mpi_real8, mpi_integer, &
+                       mpi_sum, comm3d, mpierr
+
+  implicit none
+
+  private
+
+  character(len=*), parameter :: modname = 'modslabaverage'
+
+  public :: slabavg
+
+  interface slabavg
+    module procedure slabavg_r4
+    module procedure slabavg_r8
+    module procedure slabavg_r4_masked
+    module procedure slabavg_r8_masked
+  end interface slabavg
+
+contains
+
+  !> Compute slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r4(field, nh, avg, kstart, kend)
+
+    real(4), intent(in)  :: field(:,:,:)
+    integer, intent(in)  :: nh
+    real(4), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    real(4) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    !$acc parallel loop gang default(present)
+    do k = ks, ke
+      fld_sum = 0
+      !$acc loop vector collapse(2) reduction(+: fld_sum)
+      do j = js, je
+        do i = is, ie
+          fld_sum = fld_sum + field(i,j,k)
+        end do
+      end do
+      avg(k) = fld_sum / ijtot
+    end do
+
+    ! TODO: experiment with non-blocking allreduce
+    !$acc host_data use_device(avg)
+    call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real4, mpi_sum, &
+                       comm3d, mpierr)
+    !$acc end host_data
+
+  end subroutine slabavg_r4
+
+  !> Compute slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average.
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r8(field, nh, avg, kstart, kend)
+
+    real(8), intent(in)  :: field(:,:,:)
+    integer, intent(in)  :: nh
+    real(8), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    real(8) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    !$acc parallel loop gang default(present)
+    do k = ks, ke
+      fld_sum = 0
+      !$acc loop vector collapse(2) reduction(+: fld_sum)
+      do j = js, je
+        do i = is, ie
+          fld_sum = fld_sum + field(i,j,k)
+        end do
+      end do
+      avg(k) = fld_sum / ijtot
+    end do
+
+    !$acc host_data use_device(avg)
+    call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real8, mpi_sum, &
+                       comm3d, mpierr)
+    !$acc end host_data
+
+  end subroutine slabavg_r8
+
+  !> Compute masked slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param mask Mask to apply. Values marked as .TRUE. will be included in the average.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average.
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r4_masked(field, mask, nh, avg, kstart, kend)
+
+    real(4), intent(in)  :: field(:,:,:)
+    logical, intent(in)  :: mask(:,:,:)
+    integer, intent(in)  :: nh
+    real(4), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    integer :: test, n_cells
+    real(4) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    ! Use a block to place n_cells_tot on the stack
+    block
+      integer :: n_cells_tot(ks:ke)
+
+      !$acc data create(n_cells_tot)
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        fld_sum = 0
+        n_cells = 0
+        !$acc loop vector collapse(2) reduction(+: fld_sum, n_cells)
+        do j = js, je
+          do i = is, ie
+            test = merge(1, 0, mask(i,j,k))
+            fld_sum = fld_sum + test * field(i,j,k)
+            n_cells = n_cells + test
+          end do
+        end do
+        avg(k) = fld_sum
+        n_cells_tot(k) = n_cells
+      end do
+
+      !$acc host_data use_device(avg, ne)
+      call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real4, mpi_sum, &
+                         comm3d, mpierr)
+      call mpi_allreduce(mpi_in_place, n_cells_tot, ke - ks + 1, mpi_integer, mpi_sum, &
+                         comm3d, mpierr)
+      !$acc end host_data
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        avg(k) = avg(k) / n_cells_tot(k)
+      end do
+
+      !$acc end data
+
+    end block
+
+  end subroutine slabavg_r4_masked
+
+  !> Compute masked slab averaged profile of a field.
+  !!
+  !! \param field Variable to compute slab average of.
+  !! \param mask Mask to apply. Values marked as .TRUE. will be included in the average.
+  !! \param nh Number of ghost cells.
+  !!           \note For arrays with no ghost cells, pass nh=0!
+  !! \param avg Slab averaged profile.
+  !! \param kstart Lowest vertical level to average.
+  !! \param kend Highest vertical level to average.
+  subroutine slabavg_r8_masked(field, mask, nh, avg, kstart, kend)
+    real(8), intent(in)  :: field(:,:,:)
+    logical, intent(in)  :: mask(:,:,:)
+    integer, intent(in)  :: nh
+    real(8), intent(out) :: avg(:)
+
+    integer, optional, intent(in) :: kstart, kend
+
+    integer :: i, j, k
+    integer :: is, ie, js, je, ks, ke
+    integer :: test, n_cells
+    real(8) :: fld_sum
+
+    is = lbound(field, dim=1) + nh
+    ie = ubound(field, dim=1) - nh
+    js = lbound(field, dim=2) + nh
+    je = ubound(field, dim=2) - nh
+
+    if (present(kstart)) then
+      ks = kstart
+    else
+      ks = 1
+    end if
+
+    if (present(kend)) then
+      ke = kend
+    else
+      ke = ubound(field, dim=3)
+    end if
+
+    ! Use a block to place n_cells_tot on the stack
+    block
+      integer :: n_cells_tot(ks:ke)
+
+      !$acc data create(n_cells_tot)
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        fld_sum = 0
+        n_cells = 0
+        !$acc loop vector collapse(2) reduction(+: fld_sum, n_cells)
+        do j = js, je
+          do i = is, ie
+            test = merge(1, 0, mask(i,j,k))
+            fld_sum = fld_sum + test * field(i,j,k)
+            n_cells = n_cells + test
+          end do
+        end do
+        avg(k) = fld_sum
+        n_cells_tot(k) = n_cells
+      end do
+
+      !$acc host_data use_device(avg, ne)
+      call mpi_allreduce(mpi_in_place, avg, ke - ks + 1, mpi_real4, mpi_sum, &
+              comm3d, mpierr)
+      call mpi_allreduce(mpi_in_place, n_cells_tot, ke - ks + 1, mpi_integer, mpi_sum, &
+              comm3d, mpierr)
+      !$acc end host_data
+
+      !$acc parallel loop gang default(present)
+      do k = ks, ke
+        avg(k) = avg(k) / n_cells_tot(k)
+      end do
+
+      !$acc end data
+
+    end block
+
+  end subroutine slabavg_r8_masked
+
+end module modslabaverage

--- a/src/modslabaverage.f90
+++ b/src/modslabaverage.f90
@@ -197,7 +197,9 @@ contains
   !! \param kstart Lowest vertical level to average.
   !! \param kend Highest vertical level to average.
   !! \param local Only compute average on local MPI domain.
-  subroutine slabavg_r4_masked(field, mask, nh, avg, kstart, kend, local)
+  !! \param fillvalue Value to use for fully masked layers. Default is 0.
+  subroutine slabavg_r4_masked(field, mask, nh, avg, kstart, kend, local, &
+                               fillvalue)
 
     real(4), intent(in)  :: field(:,:,:)
     logical, intent(in)  :: mask(:,:,:)
@@ -206,12 +208,13 @@ contains
 
     integer, optional, intent(in) :: kstart, kend
     logical, optional, intent(in) :: local
+    real(4), optional, intent(in) :: fillvalue
 
     integer :: i, j, k
     integer :: is, ie, js, je, ks, ke
     integer :: test, n_cells
     logical :: do_global
-    real(4) :: fld_sum
+    real(4) :: fld_sum, fillvalue_
 
     is = lbound(field, dim=1) + nh
     ie = ubound(field, dim=1) - nh
@@ -235,6 +238,9 @@ contains
     else
       do_global = .false.
     end if
+
+    fillvalue_ = 0
+    if (present(fillvalue)) fillvalue_ = fillvalue
 
     ! Use a block to place n_cells_tot on the stack
     block
@@ -269,7 +275,7 @@ contains
 
       !$acc parallel loop gang default(present)
       do k = ks, ke
-        avg(k) = avg(k) / n_cells_tot(k)
+        avg(k) = merge(avg(k) / n_cells_tot(k), fillvalue_, n_cells_tot(k) > 0)
       end do
 
       !$acc end data
@@ -288,7 +294,10 @@ contains
   !! \param kstart Lowest vertical level to average.
   !! \param kend Highest vertical level to average.
   !! \param local Only compute average on local MPI domain.
-  subroutine slabavg_r8_masked(field, mask, nh, avg, kstart, kend, local)
+  !! \param fillvalue Value to use for fully masked layers. Default is 0.
+  subroutine slabavg_r8_masked(field, mask, nh, avg, kstart, kend, local, &
+                               fillvalue)
+
     real(8), intent(in)  :: field(:,:,:)
     logical, intent(in)  :: mask(:,:,:)
     integer, intent(in)  :: nh
@@ -296,12 +305,13 @@ contains
 
     integer, optional, intent(in) :: kstart, kend
     logical, optional, intent(in) :: local
+    real(8), optional, intent(in) :: fillvalue
 
     integer :: i, j, k
     integer :: is, ie, js, je, ks, ke
     integer :: test, n_cells
     logical :: do_global
-    real(8) :: fld_sum
+    real(8) :: fld_sum, fillvalue_
 
     is = lbound(field, dim=1) + nh
     ie = ubound(field, dim=1) - nh
@@ -325,6 +335,9 @@ contains
     else
       do_global = .false.
     end if
+
+    fillvalue_ = 0
+    if (present(fillvalue)) fillvalue_ = fillvalue
 
     ! Use a block to place n_cells_tot on the stack
     block
@@ -359,7 +372,7 @@ contains
 
       !$acc parallel loop gang default(present)
       do k = ks, ke
-        avg(k) = avg(k) / n_cells_tot(k)
+        avg(k) = merge(avg(k) / n_cells_tot(k), fillvalue_, n_cells_tot(k) > 0)
       end do
 
       !$acc end data

--- a/src/modstat_profiles.f90
+++ b/src/modstat_profiles.f90
@@ -1,0 +1,241 @@
+module modstat_profiles
+
+  use modglobal,      only: kmax, fname_options, ifnamopt, checknamelisterror, &
+                            i1, j1, k1, kmax, ijtot, btime, ih, dt_lim, timee, &
+                            tres, rtimee, imax
+  use modmpi,         only: d_mpi_bcast, comm3d, mpierr, mpi_iallreduce, &
+                            mpi_request, mpi_double, mpi_in_place, mpi_sum
+  use modstat_nc
+  use modprecision,   only: field_r, longint
+  use modslabaverage, only: slabavg
+
+  implicit none
+
+  private
+
+  character(len=*), parameter :: modname = 'modstat_profiles'
+
+  public :: add_profile
+  public :: init_profiles
+  public :: sample_profiles
+  public :: sample_profile
+  public :: write_profiles
+
+  interface sample_profile
+    module procedure sample_profile
+    module procedure sample_profile_masked
+  end interface sample_profile
+
+  ! Namelist options
+  logical :: lstat
+  real    :: dtav, timeav
+
+  ! NetCDF file variables
+  character(len=*) :: fname = 'new-profiles.xxx.nc'
+  integer          :: ncid, nrec
+
+  ! NetCDF data
+  character(len=80), allocatable :: ncname(:,:)
+  character(len=80)              :: tncname(1,4)
+  real(field_r),     allocatable :: profiles(:,:)
+
+  integer          :: nvar = 0
+  integer(longint) :: idtav, itimeav, tnext, tnextwrite
+  integer          :: nsamples
+  logical          :: do_stats
+  logical          :: write_stats
+
+  real(field_r), allocatable :: slab_average(:)
+
+contains
+
+  subroutine add_profile(name, long_name, unit, dim)
+
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: long_name
+    character(len=*), intent(in) :: unit
+    character(len=*), intent(in) :: dim
+
+    character(len=80), allocatable :: tmp_ncname(:,:)
+
+    ! TODO: check for duplicate entries
+
+    ! Allocate array for metadata
+    if (.not. allocated(ncname)) then
+      allocate(ncname(1,4))
+    else
+      ! If already allocated, grow in size by 1
+      allocate(tmp_ncname(size(ncname, dim=1) + 1, 4))
+      tmp_ncname(1:nvar,:) = ncname(1:nvar,:)
+      call move_alloc(tmp_ncname, ncname)
+    end if
+
+    nvar = nvar + 1
+
+    call ncinfo(ncname(nvar,:), name, long_name, unit, dim)
+
+  end subroutine add_profile
+
+  ! Read namelist and allocate memory
+  subroutine init_profiles
+
+    integer :: ierr
+
+    namelist /NAMOUT1D/ lstat, dtav, timeav
+
+    ! Read namelist
+    if (myid == 0) then
+      open(ifnamopt, file=fname_options, status='old', iostat=ierr)
+      read(ifnamopt, NAMOUT1D, iostat=ierr)
+      call checknamelisterror(ierr, ifnamopt, 'NAMOUT1D')
+      close(ifnamopt)
+    end if
+
+    call d_mpi_bcast(lstat, 1, 0, comm3d, mpierr)
+    call d_mpi_bcast(dtav, 1, 0, comm3d, mpierr)
+    call d_mpi_bcast(timeav, 1, 0, comm3d, mpierr)
+    call d_mpi_bcast(nvar, 1, 0, comm3d, mpierr)
+
+    idtav = int(dtav / tres, kind=longint)
+    itimeav = int(timeav / tres, kind=longint)
+
+    tnext = idtav + btime
+    tnextwrite = itimeav + btime
+    nsamples = int(itimeav / idtav)
+
+    if (.not. lstat) return
+
+    allocate(profiles(kmax,nvar))
+    allocate(slab_average(1:k1))
+
+    profiles = 0
+
+    ! Initialize the NetCDF file
+    if (myid == 0) then
+      call nctiminfo(tncname(1,:))
+      call open_nc(fname, ncid, nrec, n3=kmax)
+
+      if (nrec == 0) then
+        call define_nc(ncid, 1, tncname)
+        call writestat_dims_nc(ncid)
+      end if
+
+      call define_nc(ncid, nvar, ncname)
+    end if
+
+  end subroutine init_profiles
+
+  !> Bookkeeping
+  subroutine sample_profiles
+
+    ! Do we need to sample profiles?
+    if (timee >= tnext) then
+      tnext = tnext + idtav
+      do_stats = .true.
+    else
+      do_stats = .false.
+    end if
+
+    ! Do we need to write to file?
+    if (timee >= tnextwrite) then
+      tnextwrite = tnextwrite + itimeav
+      write_stats = .true.
+    else
+      write_stats = .false.
+    end if
+
+    ! Limit time step if we need to sample soon
+    ! Note: changing a variable from another module like this is VERY ugly!!
+    dt_lim = minval([dt_lim, tnext - timee, tnextwrite - timee])
+
+  end subroutine sample_profiles
+
+  subroutine sample_profile(name, field)
+
+    character(len=*), intent(in) :: name
+    real(field_r),    intent(in) :: field(:,:,:)
+
+    character(len=*), parameter :: routine = modname//':sample_profile'
+
+    integer :: k, idx
+    integer :: nh
+    logical :: found = .false.
+
+    if (.not. do_stats) return
+
+    ! TODO: a hash is probably more efficient here
+    do idx = 1, nvar
+      if (trim(name) == trim(ncname(idx,1))) then
+        found = .true.
+        exit
+      end if
+    end do
+
+    ! A bit hacky maybe: figure out if the given field has ghost cells
+    nh = (size(field, dim=1) - imax) / 2
+
+    call slabavg(field, nh, slab_average)
+
+    do k = 1, kmax
+      profiles(k,idx) = profiles(k,idx) + slab_average(k)
+    end do
+
+  end subroutine sample_profile
+
+  subroutine sample_profile_masked(name, field, mask)
+
+    character(len=*), intent(in) :: name
+    real(field_r),    intent(in) :: field(:,:,:)
+    logical,          intent(in) :: mask(:,:,:)
+
+    character(len=*), parameter :: routine = modname//':sample_profile_masked'
+
+    integer :: k, idx
+    integer :: nh
+    logical :: found = .false.
+
+    do idx = 1, nvar
+      if (trim(name) == trim(ncname(idx,1))) then
+        found = .true.
+        exit
+      end if
+    end do
+
+    nh = (size(field, dim=1) - imax) / 2
+
+    call slabavg(field, mask, nh, slab_average)
+
+    do k = 1, kmax
+      profiles(k,idx) = profiles(k,idx) + slab_average(k)
+    end do
+
+  end subroutine sample_profile_masked
+
+  subroutine write_profiles
+
+    integer :: k, n
+    type(mpi_request) :: requests(nvar)
+
+    if (.not. write_stats) return
+
+    do n = 1, nvar
+      do k = 1, kmax
+        profiles(k,n) = profiles(k,n) / nsamples
+      end do
+    end do
+
+    if (myid == 0) then
+      call writestat_nc(ncid, 1, tncname, [rtimee], nrec, .true.)
+      call writestat_nc(ncid, nvar, ncname, profiles(1:kmax,:), nrec, kmax)
+    end if
+
+    ! Reset averages
+    do n = 1, nvar
+      do k = 1, kmax
+        profiles(k,n) = 0
+      end do
+    end do
+
+  end subroutine write_profiles
+
+end module modstat_profiles

--- a/src/modstat_profiles.f90
+++ b/src/modstat_profiles.f90
@@ -2,7 +2,7 @@ module modstat_profiles
 
   use modglobal,      only: kmax, fname_options, ifnamopt, checknamelisterror, &
                             i1, j1, k1, kmax, ijtot, btime, ih, dt_lim, timee, &
-                            tres, rtimee, imax, cexpnr
+                            tres, rtimee, imax, cexpnr, dtav_glob, timeav_glob
   use modmpi,         only: d_mpi_bcast, comm3d, mpierr, print_info_stderr, &
                             cmyidx, cmyidy
   use modstat_nc
@@ -90,6 +90,9 @@ contains
     integer :: ierr
 
     namelist /NAMOUT1D/ lstat, lprocblock, dtav, timeav
+
+    dtav = dtav_glob
+    timeav = timeav_glob
 
     ! Read namelist
     if (myid == 0) then

--- a/src/modstat_profiles.f90
+++ b/src/modstat_profiles.f90
@@ -2,7 +2,7 @@ module modstat_profiles
 
   use modglobal,      only: kmax, fname_options, ifnamopt, checknamelisterror, &
                             i1, j1, k1, kmax, ijtot, btime, ih, dt_lim, timee, &
-                            tres, rtimee, imax
+                            tres, rtimee, imax, cexpnr
   use modmpi,         only: d_mpi_bcast, comm3d, mpierr, mpi_iallreduce, &
                             mpi_request, mpi_double, mpi_in_place, mpi_sum
   use modstat_nc
@@ -31,8 +31,8 @@ module modstat_profiles
   real    :: dtav, timeav
 
   ! NetCDF file variables
-  character(len=*) :: fname = 'new-profiles.xxx.nc'
-  integer          :: ncid, nrec
+  character(len=80) :: fname
+  integer           :: ncid, nrec
 
   ! NetCDF data
   character(len=80), allocatable :: ncname(:,:)
@@ -95,6 +95,8 @@ contains
     call d_mpi_bcast(dtav, 1, 0, comm3d, mpierr)
     call d_mpi_bcast(timeav, 1, 0, comm3d, mpierr)
     call d_mpi_bcast(nvar, 1, 0, comm3d, mpierr)
+
+    fname = 'new-profiles.'//cexpnr//'.nc'
 
     idtav = int(dtav / tres, kind=longint)
     itimeav = int(timeav / tres, kind=longint)

--- a/src/modstat_profiles.f90
+++ b/src/modstat_profiles.f90
@@ -3,9 +3,7 @@ module modstat_profiles
   use modglobal,      only: kmax, fname_options, ifnamopt, checknamelisterror, &
                             i1, j1, k1, kmax, ijtot, btime, ih, dt_lim, timee, &
                             tres, rtimee, imax, cexpnr
-  use modmpi,         only: d_mpi_bcast, comm3d, mpierr, mpi_iallreduce, &
-                            mpi_request, mpi_double, mpi_in_place, mpi_sum, &
-                            print_info_stderr
+  use modmpi,         only: d_mpi_bcast, comm3d, mpierr, print_info_stderr
   use modstat_nc
   use modprecision,   only: field_r, longint
   use modslabaverage, only: slabavg
@@ -168,7 +166,6 @@ contains
 
     integer :: k, idx
     integer :: nh
-    logical :: found = .false.
 
     if (.not. do_stats) return
 
@@ -203,7 +200,6 @@ contains
 
     integer :: k, idx
     integer :: nh
-    logical :: found = .false.
 
     ! Find location in the list of profiles
     idx = findloc(ncname(:,1), value=trim(name), dim=1)
@@ -228,7 +224,6 @@ contains
   subroutine write_profiles
 
     integer :: k, n
-    type(mpi_request) :: requests(nvar)
 
     if (.not. write_stats) return
 

--- a/src/modstat_profiles.f90
+++ b/src/modstat_profiles.f90
@@ -38,7 +38,7 @@ module modstat_profiles
   ! NetCDF data
   character(len=80), allocatable :: ncname(:,:)
   character(len=80)              :: tncname(1,4)
-  real(field_r),     allocatable :: profiles(:,:)
+  real,              allocatable :: profiles(:,:)
 
   integer          :: nvar = 0
   integer(longint) :: idtav, itimeav, tnext, tnextwrite

--- a/src/modstat_profiles.f90
+++ b/src/modstat_profiles.f90
@@ -17,13 +17,13 @@ module modstat_profiles
   public :: add_profile
   public :: init_profiles
   public :: sample_profiles
-  public :: sample_profile
+  public :: sample_field
   public :: write_profiles
 
-  interface sample_profile
-    module procedure sample_profile
-    module procedure sample_profile_masked
-  end interface sample_profile
+  interface sample_field
+    module procedure sample_field
+    module procedure sample_field_masked
+  end interface sample_field
 
   ! Namelist options
   logical :: lstat
@@ -157,7 +157,7 @@ contains
 
   end subroutine sample_profiles
 
-  subroutine sample_profile(name, field)
+  subroutine sample_field(name, field)
 
     character(len=*), intent(in) :: name
     real(field_r),    intent(in) :: field(:,:,:)
@@ -188,9 +188,9 @@ contains
       profiles(k,idx) = profiles(k,idx) + slab_average(k)
     end do
 
-  end subroutine sample_profile
+  end subroutine sample_field
 
-  subroutine sample_profile_masked(name, field, mask)
+  subroutine sample_field_masked(name, field, mask)
 
     character(len=*), intent(in) :: name
     real(field_r),    intent(in) :: field(:,:,:)
@@ -219,7 +219,7 @@ contains
       profiles(k,idx) = profiles(k,idx) + slab_average(k)
     end do
 
-  end subroutine sample_profile_masked
+  end subroutine sample_field_masked
 
   subroutine write_profiles
 

--- a/src/program.f90
+++ b/src/program.f90
@@ -162,6 +162,7 @@ program DALES
   use moddatetime,     only : datetime
   use modemission,     only : emission
   use modopenboundary, only : openboundary_ghost,openboundary_tend,openboundary_phasevelocity,openboundary_turb
+  use modstat_profiles, only: init_profiles, sample_profiles, write_profiles
 
 !----------------------------------------------------------------
 !     0.2     USE STATEMENTS FOR TIMER MODULE
@@ -226,6 +227,8 @@ program DALES
   !call initspectra2
   call initcape
 
+  call init_profiles
+
 #if defined(_OPENACC)
   call update_gpu
 #endif
@@ -239,6 +242,10 @@ program DALES
   istep = 1
   do while (timeleft>0 .or. rk3step < 3)
     call timer_tic('program/timestep', istep)
+
+    ! Check if we have to sample profiles this time step
+    call sample_profiles
+
     ! Calculate new timestep, and reset tendencies to 0.
     call tstep_update
     call timedep
@@ -337,6 +344,7 @@ program DALES
     call checksim
     call timestat  !Timestat must preceed all other timeseries that could write in the same netCDF file (unless stated otherwise
     call genstat  !Genstat must preceed all other statistics that could write in the same netCDF file (unless stated otherwise
+    call write_profiles
     call radstat
     call lsmstat
     !call depstat


### PR DESCRIPTION
This PR adds a new module (`modstat_profiles`) which aims to make the process of writing vertical profiles to a NetCDF file easier. It follows from discussions that Fredrik and I had about the statistical routines for bulk microphysics.

Basically, the new module keeps a list of vertical profiles. From any location in the program, a profile can be added using the subroutine `add_profile`. A field can then be sampled using the functions `sample_field` or `sample_field_masked` for masked statistics.