### PR TITLE
Dev pressuregradient

### DIFF
--- a/src/modboundary.f90
+++ b/src/modboundary.f90
@@ -220,12 +220,12 @@ contains
     end do
     !$acc end kernels
     if(lcoriol) then
-    !$acc kernels default(present) async(1)
-    do k=ksp,kmax
-      up(:,:,k)  = up(:,:,k)-(u0(:,:,k)-(ug(k)-cu))*((1./(geodamptime*rnu0))*tsc(k))
-      vp(:,:,k)  = vp(:,:,k)-(v0(:,:,k)-(vg(k)-cv))*((1./(geodamptime*rnu0))*tsc(k))
-    end do
-    !$acc end kernels
+      !$acc kernels default(present) async(1)
+      do k=ksp,kmax
+        up(:,:,k)  = up(:,:,k)-(u0(:,:,k)-(ug(k)-cu))*((1./(geodamptime*rnu0))*tsc(k))
+        vp(:,:,k)  = vp(:,:,k)-(v0(:,:,k)-(vg(k)-cv))*((1./(geodamptime*rnu0))*tsc(k))
+      end do
+      !$acc end kernels
     end if
   case(2)
     !$acc kernels default(present) async(1)

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -63,7 +63,7 @@ contains
 !                                                                 |
 !-----------------------------------------------------------------|
 
-  use modglobal, only : kmax,dzh,dzf,grav, lpressgrad
+  use modglobal, only : kmax,dzh,dzf,grav, lpressgrad, lcoriol
   use modfields, only : sv0,up,vp,wp,thv0h,dpdxl,dpdyl,thvh
   use moduser,   only : force_user
   use modmicrodata, only : imicro, imicro_bulk, imicro_bin, imicro_sice, imicro_sice2, iqr
@@ -75,13 +75,14 @@ contains
 
   if (lforce_user) call force_user
 
-  if (lpressgrad) then
-     !$acc kernels default(present) async(1)
-     do k = 1, kmax
-        up(:,:,k) = up(:,:,k) - dpdxl(k)      !RN LS pressure gradient force in x,y directions;
-        vp(:,:,k) = vp(:,:,k) - dpdyl(k)
-     end do
-     !$acc end kernels
+  ! Apply pressure gradient calculated from geostrophic wind speeds (lcoriol) or imposed pressure gradient (lpressgrad)
+  if (lcoriol .or. lpressgrad) then
+    !$acc kernels default(present) async(1)
+    do k = 1, kmax
+      up(:,:,k) = up(:,:,k) - dpdxl(k)      ! LS pressure gradient force in x,y directions;
+      vp(:,:,k) = vp(:,:,k) - dpdyl(k)
+    end do
+    !$acc end kernels
   end if
 
   if((imicro==imicro_sice).or.(imicro==imicro_sice2).or.(imicro==imicro_bulk).or.(imicro==imicro_bin)) then
@@ -156,7 +157,7 @@ contains
         end do
       end do
     end do
-    
+
     !$acc parallel loop collapse(3) default(present) async(1)
     do k = 1, kmax
       do j = sy, j1
@@ -166,7 +167,7 @@ contains
         end do
       end do
     end do
-    
+
     !$acc parallel loop collapse(3) default(present) async(1)
     do k = 2, kmax
       do j = 2, j1
@@ -258,7 +259,7 @@ contains
                         dudxls,dudyls,dvdxls,dvdyls,dthldxls,dthldyls,dqtdxls,dqtdyls, &
                         dqtdtls, dthldtls, dudtls, dvdtls
   implicit none
-  
+
   integer i, j, k, n
 
   call timer_tic('modforces/lstend', 0)

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -106,7 +106,7 @@ save
       real,parameter :: gamma_T_water  = 0.57       !< Heat conductivity water [J s-1 m-1 K-1]
 
       logical :: lcoriol  = .true.  !<  switch for coriolis force
-      logical :: lpressgrad = .true.  !<  switch for horizontal pressure gradient force
+      logical :: lpressgrad = .false.  !<  switch for horizontal pressure gradient force (only intended for channel-like pressure-driven flow, not to be used in combination with coriolis force; thus default to false)
       integer       :: igrw_damp = 2 !< switch to enable gravity wave damping
       real(field_r) :: geodamptime = 7200. !< time scale for nudging to geowind in sponge layer, prevents oscillations
       real(field_r) :: uvdamprate = 0.  !< rate for damping mean horizontal wind
@@ -375,13 +375,10 @@ contains
     phi    = xlat*pi/180.
     colat  = cos(phi)
     silat  = sin(phi)
-    if (lcoriol) then
-      omega = 7.292e-5
-      omega_gs = 7.292e-5
-    else
-      omega = 0.
-      omega_gs = 0.
-    end if
+
+    omega = 7.292e-5
+    omega_gs = 7.292e-5
+
     om22   = 2.*omega*colat
     om23   = 2.*omega*silat
     om22_gs   = 2.*omega_gs*colat
@@ -389,7 +386,6 @@ contains
 
     ! Variables
     write(cexpnr,'(i3.3)') iexpnr
-
 
     ! Create the physical grid variables
     allocate(dzf(k1), dzfi(k1))

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -105,8 +105,8 @@ save
       real,parameter :: gamma_T_matrix = 3.4293695508945325 !< Heat conductivity soil [J s-1 m-1 K-1]
       real,parameter :: gamma_T_water  = 0.57       !< Heat conductivity water [J s-1 m-1 K-1]
 
-      logical :: lcoriol  = .true.  !<  switch for coriolis force
-      logical :: lpressgrad = .false.  !<  switch for horizontal pressure gradient force (only intended for channel-like pressure-driven flow, not to be used in combination with coriolis force; thus default to false)
+      logical       :: lcoriol  = .true.  !<  switch for coriolis force
+      logical       :: lpressgrad = .false.  !<  switch for horizontal pressure gradient (not to be used in combination with coriolis force)
       integer       :: igrw_damp = 2 !< switch to enable gravity wave damping
       real(field_r) :: geodamptime = 7200. !< time scale for nudging to geowind in sponge layer, prevents oscillations
       real(field_r) :: uvdamprate = 0.  !< rate for damping mean horizontal wind

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -424,7 +424,8 @@ contains
   subroutine checkinitvalues
     use modsurfdata, only: wtsurf, wqsurf, ustin, thls, isurf, ps, lhetero
     use modglobal,   only: itot, jtot, ysize, xsize, dtmax, runtime, &
-                           startfile, lwarmstart, eps1, imax, jmax, ih, jh
+                           startfile, lwarmstart, eps1, imax, jmax, ih, jh, &
+                           lcoriol, lpressgrad
     use modmpi,      only: myid, nprocx, nprocy, mpierr, MPI_FINALIZE
     use modtimedep,  only: ltimedep
 
@@ -515,6 +516,9 @@ contains
       end if
     end if
 
+    if (lcoriol .and. lpressgrad) then
+      if (myid==0) stop "Coriolis force (lcoriol) and channel-like pressure gradient (lpressgrad) are mutually exclusive. To use Coriolis force with NO pressure gradient, set geowinds to zero."
+   end if
   end subroutine checkinitvalues
 
   subroutine readinitfiles
@@ -530,7 +534,7 @@ contains
                                   zf,dzf,dzh,rv,rd,cp,rlv,pref0,om23_gs,&
                                   ijtot,cu,cv,e12min,dzh,cexpnr,ifinput,lwarmstart,ltotruntime,itrestart,&
                                   trestart, ladaptive,llsadv,tnextrestart,longint,lconstexner,lopenbc, linithetero, &
-                                  iinput, input_netcdf, input_ascii
+                                  iinput, input_netcdf, input_ascii, lcoriol
     use modsubgrid,        only : ekm,ekh
     use modsurfdata,       only : wsvsurf, &
                                   thls,tskin,tskinm,tsoil,tsoilm,phiw,phiwm,Wl,Wlm,thvs,qts,isurf,svs,obl,oblav,&
@@ -607,7 +611,7 @@ contains
 
         else if (iinput == input_netcdf) then
           call init_from_netcdf('init.'//cexpnr//'.nc', height, uprof, vprof, &
-                                thlprof, qtprof, e12prof, ug, vg, wfls, &
+                                thlprof, qtprof, e12prof, ug, vg, dpdxl, dpdyl, wfls, &
                                 dqtdxls, dqtdyls, dqtdtls, thlpcar, kmax)
           call tracer_profs_from_netcdf('tracers.'//cexpnr//'.nc', &
                                         tracer_prop, svprof(1:kmax,:))
@@ -1058,6 +1062,8 @@ contains
 
     call D_MPI_BCAST(ug       ,kmax,0,comm3d,mpierr)
     call D_MPI_BCAST(vg       ,kmax,0,comm3d,mpierr)
+    call D_MPI_BCAST(dpdxl    ,kmax,0,comm3d,mpierr)
+    call D_MPI_BCAST(dpdyl    ,kmax,0,comm3d,mpierr)
     call D_MPI_BCAST(wfls     ,kmax,0,comm3d,mpierr)
     call D_MPI_BCAST(dqtdxls  ,kmax,0,comm3d,mpierr)
     call D_MPI_BCAST(dqtdyls  ,kmax,0,comm3d,mpierr)
@@ -1069,12 +1075,12 @@ contains
     !-----------------------------------------------------------------
 
     !******include rho if rho = rho(z) /= 1.0 ***********
-
-    do k = 1, kmax
-      dpdxl(k) =  om23_gs*vg(k)
-      dpdyl(k) = -om23_gs*ug(k)
-    end do
-
+    if (lcoriol) then  ! only when Coriolis is enabled, calculte pressure gradients via geostrophic wind speeds (otherwise assume they have been set already)
+       do k = 1, kmax
+          dpdxl(k) =  om23_gs*vg(k)
+          dpdyl(k) = -om23_gs*ug(k)
+       end do
+    end if
     !-----------------------------------------------------------------
     !    2.5 make large-scale horizontal gradients
     !-----------------------------------------------------------------
@@ -1804,7 +1810,7 @@ contains
   !! \note Tracers are read from tracers.XXX.nc, not here.
   !! \todo Make DEPHY-compatible.
   subroutine init_from_netcdf(filename, height, uprof, vprof, thlprof, qtprof, &
-                              e12prof, ug, vg, wfls, dqtdxls, dqtdyls, &
+                              e12prof, ug, vg, dpdxl, dpdyl, wfls, dqtdxls, dqtdyls, &
                               dqtdtls, dthlrad, kmax)
     character(*),   intent(in)  :: filename
     real(field_r),  intent(out) :: height(:)
@@ -1815,6 +1821,8 @@ contains
     real(field_r),  intent(out) :: e12prof(:)
     real(field_r),  intent(out) :: ug(:)
     real(field_r),  intent(out) :: vg(:)
+    real(field_r),  intent(out) :: dpdxl(:)
+    real(field_r),  intent(out) :: dpdyl(:)
     real(field_r),  intent(out) :: wfls(:)
     real(field_r),  intent(out) :: dqtdxls(:)
     real(field_r),  intent(out) :: dqtdyls(:)
@@ -1843,6 +1851,10 @@ contains
     call read_nc_field(ncid, "ug", ug, start=1, count=kmax, &
                        fillvalue=0._field_r)
     call read_nc_field(ncid, "vg", vg, start=1, count=kmax, &
+                       fillvalue=0._field_r)
+    call read_nc_field(ncid, "dpdx", dpdxl, start=1, count=kmax, &
+                       fillvalue=0._field_r)
+    call read_nc_field(ncid, "dpdy", dpdyl, start=1, count=kmax, &
                        fillvalue=0._field_r)
     call read_nc_field(ncid, "wa", wfls, start=1, count=kmax, &
                        fillvalue=0._field_r)

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1025,9 +1025,44 @@ contains
           end if
           read (ifinput,'(a80)') chmess
           read (ifinput,'(a80)') chmess
-          do  k=1,kmax
-            read (ifinput,*) &
-                height (k), &
+
+          ! if coriolis force, read in 2nd and 3rd columns as ug and vg
+          if (lcoriol) then 
+            do  k=1,kmax
+              read (ifinput,*) &
+                  height (k), &
+                  ug     (k), &
+                  vg     (k), &
+                  wfls   (k), &
+                  dqtdxls(k), &
+                  dqtdyls(k), &
+                  dqtdtls(k), &
+                  thlpcar(k)
+            end do
+          else ! otherwhise read in same columns as pressure gradient
+            do  k=1,kmax
+              read (ifinput,*) &
+                  height (k), &
+                  dpdxl  (k), &
+                  dpdyl  (k), &
+                  wfls   (k), &
+                  dqtdxls(k), &
+                  dqtdyls(k), &
+                  dqtdtls(k), &
+                  thlpcar(k)
+            end do
+          end if 
+          close(ifinput)
+        end if
+
+      end if
+
+      if (lcoriol) then
+        write(6,*) ' height u_geo   v_geo    subs     ' &
+                  ,'   dqtdx      dqtdy        dqtdtls     thl_rad '
+        do k=kmax,1,-1
+          write (6,'(3f7.1,5e12.4)') &
+                zf     (k), &
                 ug     (k), &
                 vg     (k), &
                 wfls   (k), &
@@ -1035,26 +1070,22 @@ contains
                 dqtdyls(k), &
                 dqtdtls(k), &
                 thlpcar(k)
-          end do
-          close(ifinput)
-        end if
-
-      end if
-
-      write(6,*) ' height u_geo   v_geo    subs     ' &
-                ,'   dqtdx      dqtdy        dqtdtls     thl_rad '
-      do k=kmax,1,-1
-        write (6,'(3f7.1,5e12.4)') &
-              zf     (k), &
-              ug     (k), &
-              vg     (k), &
-              wfls   (k), &
-              dqtdxls(k), &
-              dqtdyls(k), &
-              dqtdtls(k), &
-              thlpcar(k)
-      end do
-
+        end do
+      else
+        write(6,*) ' height u_geo   v_geo    subs     ' &
+        ,'   dqtdx      dqtdy        dqtdtls     thl_rad '
+        do k=kmax,1,-1
+          write (6,'(3f7.1,5e12.4)') &
+                zf     (k), &
+                dpdxl  (k), &
+                dpdyl  (k), &
+                wfls   (k), &
+                dqtdxls(k), &
+                dqtdyls(k), &
+                dqtdtls(k), &
+                thlpcar(k)
+        end do
+      end if 
 
     end if ! end myid==0
 

--- a/src/modtimedep.f90
+++ b/src/modtimedep.f90
@@ -281,7 +281,7 @@ contains
                       dqtdtlst(k,t), &
                       thlpcart(k,t)
               end do
-            else ! else read in same columns as pressure gradients dpdx and dpdy (chosen for this approach as these columns anyway MUST exist in ls_flux.inp.xxx)
+            else ! else read in same columns as dpdx and dpdy
                 do k=1,kmax
                   read (ifinput,*) &
                         height  (k)  , &

--- a/src/modtimedep.f90
+++ b/src/modtimedep.f90
@@ -56,6 +56,8 @@ save
   real, allocatable     :: timels  (:)
   real, allocatable     :: ugt     (:,:)
   real, allocatable     :: vgt     (:,:)
+  real, allocatable     :: dpdxlt  (:,:)
+  real, allocatable     :: dpdylt  (:,:)
   real, allocatable     :: wflst   (:,:)
   real, allocatable     :: dqtdxlst(:,:)
   real, allocatable     :: dqtdylst(:,:)
@@ -67,13 +69,11 @@ save
   real, allocatable     :: thlproft(:,:)
   real, allocatable     :: qtproft (:,:)
 
-
-
 contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine inittimedep
     use modmpi,    only :myid,mpierr,comm3d,D_MPI_BCAST
-    use modglobal, only :cexpnr,k1,kmax,ifinput,runtime,zf,ntimedep
+    use modglobal, only :cexpnr,k1,kmax,ifinput,runtime,zf,ntimedep,lcoriol
     use modsurfdata,only :ps,qts,wqsurf,wtsurf,thls, Qnetav
     use modtimedepsv, only : inittimedepsv
 
@@ -112,6 +112,8 @@ contains
     allocate(timels   (0:kls))
     allocate(ugt      (k1,kls))
     allocate(vgt      (k1,kls))
+    allocate(dpdxlt   (k1,kls))
+    allocate(dpdylt   (k1,kls))
     allocate(wflst    (k1,kls))
 
     allocate(dqtdxlst (k1,kls))
@@ -139,6 +141,8 @@ contains
 
     ugt      = 0
     vgt      = 0
+    dpdxlt   = 0
+    dpdylt   = 0
     wflst    = 0
 
     dqtdxlst = 0
@@ -164,7 +168,7 @@ contains
       if (ltestbed) then
 
         write(*,*) 'inittimedep: testbed mode: data for time-dependent forcing obtained from scm_in.nc'
-      
+
         timeflux(1:kflux) = tb_time
         timels  (1:kls  ) = tb_time
 
@@ -189,7 +193,7 @@ contains
         end do
 
       else
-    
+
         open(ifinput,file='ls_flux.inp.'//cexpnr)
         read(ifinput,'(a80)') chmess
         write(6,*) chmess
@@ -208,7 +212,7 @@ contains
         do while (timeflux(t) < runtime)
           t=t+1
           if (t > kflux) then
-             write (*,*) "Too many time points in file ", 'ls_flux.inp.'//cexpnr, ", the limit is kflux = ", kflux 
+             write (*,*) "Too many time points in file ", 'ls_flux.inp.'//cexpnr, ", the limit is kflux = ", kflux
              stop
           end if
           read(ifinput,*, iostat = ierr) timeflux(t), wtsurft(t), wqsurft(t),thlst(t),qtst(t),pst(t)
@@ -245,6 +249,8 @@ contains
               stop 'STOP: No time dependend data for end of run'
             end if
           end do
+
+
           if (ltimedepuv) then
              ! new, optional format with u,v in ls_flux.inp.*
              do k=1,kmax
@@ -261,25 +267,41 @@ contains
                      dvdtlst (k,t)
              end do
           else
-             ! old format without u,v in ls_flux.inp.*  (default)
-             do k=1,kmax
+            ! if lcoriol, read in 2nd and 3rd column as ug and vg
+            if (lcoriol) then
+              ! old format without u,v in ls_flux.inp.*  (default)
+              do k=1,kmax
                 read (ifinput,*) &
-                     height  (k)  , &
-                     ugt     (k,t), &
-                     vgt     (k,t), &
-                     wflst   (k,t), &
-                     dqtdxlst(k,t), &
-                     dqtdylst(k,t), &
-                     dqtdtlst(k,t), &
-                     thlpcart(k,t)
-             end do
+                      height  (k)  , &
+                      ugt     (k,t), &
+                      vgt     (k,t), &
+                      wflst   (k,t), &
+                      dqtdxlst(k,t), &
+                      dqtdylst(k,t), &
+                      dqtdtlst(k,t), &
+                      thlpcart(k,t)
+              end do
+            else ! else read in same columns as pressure gradients dpdx and dpdy (chosen for this approach as these columns anyway MUST exist in ls_flux.inp.xxx)
+                do k=1,kmax
+                  read (ifinput,*) &
+                        height  (k)  , &
+                        dpdxlt  (k,t), &
+                        dpdylt  (k,t), &
+                        wflst   (k,t), &
+                        dqtdxlst(k,t), &
+                        dqtdylst(k,t), &
+                        dqtdtlst(k,t), &
+                        thlpcart(k,t)
+                end do
+            end if
+
+
           end if
-       end do
+        end do
 
         close(ifinput)
 
       end if   !ltestbed
-
 
 !      do k=kmax,1,-1
 !        write (6,'(3f7.1,5e12.4)') &
@@ -292,7 +314,6 @@ contains
 !            dqtdtlst(k,t), &
 !            thlpcart(k,t)
 !      end do
-
 
       if(timeflux(1)>runtime) then
         write(6,*) 'Time dependent surface variables do not change before end of'
@@ -320,6 +341,8 @@ contains
     call D_MPI_BCAST(timels(1:kls)    ,kls     ,0,comm3d,mpierr)
     call D_MPI_BCAST(ugt              ,kmax*kls,0,comm3d,mpierr)
     call D_MPI_BCAST(vgt              ,kmax*kls,0,comm3d,mpierr)
+    call D_MPI_BCAST(dpdxlt           ,kmax*kls,0,comm3d,mpierr)
+    call D_MPI_BCAST(dpdylt           ,kmax*kls,0,comm3d,mpierr)
     call D_MPI_BCAST(wflst            ,kmax*kls,0,comm3d,mpierr)
     call D_MPI_BCAST(dqtdxlst,kmax*kls ,0,comm3d,mpierr)
     call D_MPI_BCAST(dqtdylst,kmax*kls ,0,comm3d,mpierr)
@@ -381,7 +404,7 @@ contains
                             dvdtls,dvdxls,dvdyls, &
                             dpdxl,dpdyl
 
-    use modglobal,   only : rtimee,om23_gs,dzf,dzh,k1,kmax,llsadv
+    use modglobal,   only : rtimee,om23_gs,dzf,dzh,k1,kmax,llsadv,lcoriol
 
     use modmpi,      only : myid
 
@@ -412,11 +435,15 @@ contains
     dvdtls   = dvdtlst  (:,t) + fac * ( dvdtlst  (:,t+1) - dvdtlst  (:,t) )
     thlpcar  = thlpcart (:,t) + fac * ( thlpcart (:,t+1) - thlpcart (:,t) )
 
-
-    do k=1,kmax
-      dpdxl(k) =  om23_gs*vg(k)
-      dpdyl(k) = -om23_gs*ug(k)
-    end do
+    if (lcoriol) then
+      do k=1,kmax
+        dpdxl(k) =  om23_gs*vg(k)
+        dpdyl(k) = -om23_gs*ug(k)
+      end do
+    else ! if not lcoriol, update regular pressure gradients
+      dpdxl      = dpdxlt (:,t) + fac * ( dpdxlt (:,t+1) - dpdxlt (:,t) )
+      dpdyl      = dpdylt (:,t) + fac * ( dpdylt (:,t+1) - dpdylt (:,t) )
+    end if
 
     whls(1)  = 0.0
     do k=2,kmax


### PR DESCRIPTION
Add the option to run with a specified pressure gradient instead of specified geostrophic wind.
By Steven van der Linden, continuation of work in #156.


*  Added new option for horizontal pressure gradient (to enable pressure-driven channel flow). Also supports time-dependent pressure gradient.
* lcoriol and lpressgrad switches are now mutually exclusive, fixing implicit behavior that pressure gradient would always be set to zero, when lcoriol=.false. (see modforces.f90, lines 370-379).
* Input infrastructure remains the same. Columns in lscale.inp.iii are read in as either geostrophic winds (when lcoriol=.true. or as horizontal pressure gradients when lpressgrad=.true.. Same for netcdf input.
* Error is produced when both are set to true.

Background: the old switch lpressgrad would have allowed to impose no pressure gradients, whilst still allowing Coriolis forces. This option is now made explicit: you must put geostrophic winds to zero when you want this to happen (as intuitively most of us would have already done anyway)
