### PR TITLE
rrtmg_lw: update to latest version 5.0, 2020

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,8 +140,6 @@ set( rrtmg_lw_srcs
 	${PROJECT_SOURCE_DIR}/external/RRTMG/RRTMG_LW/src/rrtmg_lw_rtrnmr.f90
 	${PROJECT_SOURCE_DIR}/external/RRTMG/RRTMG_LW/src/rrtmg_lw_setcoef.f90
 	${PROJECT_SOURCE_DIR}/external/RRTMG/RRTMG_LW/src/rrtmg_lw_taumol.f90
-	${PROJECT_SOURCE_DIR}/external/RRTMG/RRTMG_LW/src/src_link
-	${PROJECT_SOURCE_DIR}/external/RRTMG/RRTMG_LW/src/util_link
 )
 
 # RRTMG - shortwave

--- a/src/modradrrtmg.f90
+++ b/src/modradrrtmg.f90
@@ -203,7 +203,7 @@ contains
 
       if (rad_longw) then
         call rrtmg_lw & !comments = corresponding variable names in the RRTMGP library
-                (int(imax,kind_im), int(nzrad+1,kind_im), ioverlap, & !ncol, nlay, icld, (+ idrv in later versions !)
+                (int(imax,kind_im), int(nzrad+1,kind_im), ioverlap, 0, & !ncol, nlay, icld, (+ idrv in later versions !)
                  layerP, interfaceP, layerT, interfaceT, tg_slice, & !play, plev, tlay, tlev, tsfc
                  h2ovmr, o3vmr, co2vmr, ch4vmr, n2ovmr, o2vmr, & !h2ovmr, o3vmr, co2vmr, ch4vmr, n2ovmr, o2vmr
                  cfc11vmr, cfc12vmr, cfc22vmr, ccl4vmr, emis, & !cfc11vmr, cfc12vmr, cfc22vmr, ccl4vmr, emis


### PR DESCRIPTION
Reason for update: one bug in upstream RRTMG-LW related to clouds in the first model layer has been fixed.

One change needed on the DALES side: the function rrtmg_lw now requires one extra argument idrv. We set idrv = 0 to get the same behavior as before. idrv = 1 can be used to request some extra output.

I have tested the dev branch with and without this commit on a small-domain botany case (run 12h with current dev, then restart with dev or with this branch, run for 900s, compare those). No changes seen in the various LW radfields, although they don't seem bitwise identical.