### PR TITLE
Fix RRTMG_LW submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/RRTMG/RRTMG_LW"]
 	path = external/RRTMG/RRTMG_LW
-	url = https://github.com/dalesteam/RRTMG_LW/
+	url = https://github.com/AER-RC/RRTMG_LW/
 [submodule "src/RRTMG/RRTMG_SW"]
 	path = external/RRTMG/RRTMG_SW
 	url = https://github.com/dalesteam/RRTMG_SW.git


### PR DESCRIPTION
- point to upstream repository now our fix is merged there
- use https instead of ssh remote repository