### PR TITLE
D80R subgrid scheme

### DIFF
--- a/src/modsubgriddata.f90
+++ b/src/modsubgriddata.f90
@@ -37,6 +37,7 @@ save
   logical :: lmason       = .false. !<  switch for decreased length scale near the surface
   logical :: lsmagorinsky = .false. !<  switch for smagorinsky subgrid scheme
   logical :: lanisotrop   = .false. !<  switch for anisotropic diffusion
+  logical :: lD80R        = .false. !<  switch for D80R subgrid scheme
 
   real(field_r) :: cf      = 2.5  !< filter constant
   real(field_r) :: Rigc    = 0.25 !< critical Richardson number
@@ -63,6 +64,5 @@ save
 
   real(field_r), allocatable :: csz(:)       !< Smagorinsky constant
 
-  real(field_r), allocatable :: anis_fac(:)  !< grid anisotropy factor 
+  real(field_r), allocatable :: anis_fac(:)  !< grid anisotropy factor
 end module modsubgriddata
-


### PR DESCRIPTION
D80R subgrid scheme, for stable nocturnal boundary layers simulated with coarse resolution. Activated by lD80R flag in &NAMSUBGRID.

Reference:
Y. Dai, S. Basu, B. Maronga, S. R. de Roode,
Addressing the grid-size sensitivity issue in large-eddy simulations of stable boundary layers. Boundary-Layer Meteorology, 178, 63-89 (2021).

Originally implemented by Yi Dai in PR #63.