### PR TITLE
modbulkmicrostat3: use allreduce instead of reduce

### DIFF
--- a/src/modbulkmicrostat3.f90
+++ b/src/modbulkmicrostat3.f90
@@ -379,7 +379,7 @@ subroutine initbulkmicrostat3
     use modstat_nc, only : lnetcdf, writestat_nc
 !    use modgenstat, only : nrec_prof=>nrec
     use modmicrodata3
-    use modmpi,    only  : comm3d, mpierr, D_MPI_REDUCE
+    use modmpi,    only  : comm3d, mpierr, D_MPI_ALLREDUCE
 
     implicit none
     integer  :: nsecs, nhrs, nminut
@@ -392,12 +392,12 @@ subroutine initbulkmicrostat3
 
     ! gather all columns
     if (l_statistics) then
-      call D_MPI_REDUCE(statistic_mphys    ,size(statistic_mphys    ),MPI_SUM,0,comm3d,mpierr)
-      call D_MPI_REDUCE(statistic_sv0_count,size(statistic_sv0_count),MPI_SUM,0,comm3d,mpierr)
-      call D_MPI_REDUCE(statistic_sv0_fsum ,size(statistic_sv0_fsum ),MPI_SUM,0,comm3d,mpierr)
-      call D_MPI_REDUCE(statistic_sv0_csum ,size(statistic_sv0_csum ),MPI_SUM,0,comm3d,mpierr)
-      call D_MPI_REDUCE(statistic_svp_fsum ,size(statistic_sv0_fsum ),MPI_SUM,0,comm3d,mpierr)
-      call D_MPI_REDUCE(statistic_svp_csum ,size(statistic_sv0_csum ),MPI_SUM,0,comm3d,mpierr)
+      call D_MPI_ALLREDUCE(statistic_mphys    ,size(statistic_mphys    ),MPI_SUM,comm3d,mpierr)
+      call D_MPI_ALLREDUCE(statistic_sv0_count,size(statistic_sv0_count),MPI_SUM,comm3d,mpierr)
+      call D_MPI_ALLREDUCE(statistic_sv0_fsum ,size(statistic_sv0_fsum ),MPI_SUM,comm3d,mpierr)
+      call D_MPI_ALLREDUCE(statistic_sv0_csum ,size(statistic_sv0_csum ),MPI_SUM,comm3d,mpierr)
+      call D_MPI_ALLREDUCE(statistic_svp_fsum ,size(statistic_sv0_fsum ),MPI_SUM,comm3d,mpierr)
+      call D_MPI_ALLREDUCE(statistic_svp_csum ,size(statistic_sv0_csum ),MPI_SUM,comm3d,mpierr)
 
       ! normalize
       statistic_sv0_fsum = statistic_sv0_fsum / ijtot / nsamples
@@ -413,7 +413,7 @@ subroutine initbulkmicrostat3
     endif
 
     if (l_tendencies) then
-      call D_MPI_REDUCE(tend_fsum          ,size(tend_fsum          ),MPI_SUM,0,comm3d,mpierr)
+      call D_MPI_ALLREDUCE(tend_fsum, size(tend_fsum), MPI_SUM, comm3d, mpierr)
 
       ! normalize
       tend_fsum = tend_fsum / ijtot / nsamples

--- a/src/modgpumpiinterface.f90
+++ b/src/modgpumpiinterface.f90
@@ -309,6 +309,24 @@ contains
     call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL8, op, comm, ierror)
     if (ierror /= MPI_SUCCESS) call abort
   end subroutine D_MPI_ALLREDUCE_REAL64_IP_GPU
+  subroutine D_MPI_ALLREDUCE_REAL32_IP_R2_GPU(recvbuf, count, op, comm, ierror)
+    implicit none
+    real(real32), device, contiguous, intent(inout)   :: recvbuf(:,:)
+    integer        :: count, ierror
+    type(MPI_OP)   :: op
+    type(MPI_COMM) :: comm
+    call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL4, op, comm, ierror)
+    if (ierror /= MPI_SUCCESS) call abort
+  end subroutine D_MPI_ALLREDUCE_REAL32_IP_R2_GPU
+  subroutine D_MPI_ALLREDUCE_REAL64_IP_R2_GPU(recvbuf, count, op, comm, ierror)
+    implicit none
+    real(real64), device, contiguous, intent(inout)   :: recvbuf(:,:)
+    integer        :: count, ierror
+    type(MPI_OP)   :: op
+    type(MPI_COMM) :: comm
+    call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL8, op, comm, ierror)
+    if (ierror /= MPI_SUCCESS) call abort
+  end subroutine D_MPI_ALLREDUCE_REAL64_IP_R2_GPU
 
 !>D_MPI_ALLTOALL
   subroutine D_MPI_ALLTOALL_REAL32_R1_GPU(sendbuf, sendcount, recvbuf, recvcount, comm, ierror)

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -155,6 +155,8 @@ interface D_MPI_ISEND
     procedure :: D_MPI_ALLREDUCE_INT32_R2
     procedure :: D_MPI_ALLREDUCE_REAL32_IP
     procedure :: D_MPI_ALLREDUCE_REAL64_IP
+    procedure :: D_MPI_ALLREDUCE_REAL32_IP_R2
+    procedure :: D_MPI_ALLREDUCE_REAL64_IP_R2
 #if defined(_OPENACC)
     procedure :: D_MPI_ALLREDUCE_REAL32_S_GPU
     procedure :: D_MPI_ALLREDUCE_REAL64_S_GPU
@@ -169,6 +171,8 @@ interface D_MPI_ISEND
     procedure :: D_MPI_ALLREDUCE_INT32_R2_GPU
     procedure :: D_MPI_ALLREDUCE_REAL32_IP_GPU
     procedure :: D_MPI_ALLREDUCE_REAL64_IP_GPU
+    procedure :: D_MPI_ALLREDUCE_REAL32_IP_R2_GPU
+    procedure :: D_MPI_ALLREDUCE_REAL64_IP_R2_GPU
 #endif
   end interface
   interface D_MPI_ALLTOALL
@@ -188,8 +192,8 @@ interface D_MPI_ISEND
     procedure :: D_MPI_REDUCE_REAL64_R1
     procedure :: D_MPI_REDUCE_REAL64_R2
     procedure :: D_MPI_REDUCE_REAL64_R3
-    procedure :: D_MPI_REDUCE_REAL32_IP_R1
-    procedure :: D_MPI_REDUCE_REAL32_IP_R2
+    procedure :: D_MPI_REDUCE_REAL32_IP_R1 ! inplace variants (single buffer arg) must be called
+    procedure :: D_MPI_REDUCE_REAL32_IP_R2 ! only on root process
     procedure :: D_MPI_REDUCE_REAL64_IP_R1
     procedure :: D_MPI_REDUCE_REAL64_IP_R2
 #if defined(_OPENACC)

--- a/src/modmpiinterface.f90
+++ b/src/modmpiinterface.f90
@@ -353,6 +353,24 @@ contains
     call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL8, op, comm, ierror)
     if (ierror /= MPI_SUCCESS) call abort
   end subroutine D_MPI_ALLREDUCE_REAL64_IP
+    subroutine D_MPI_ALLREDUCE_REAL32_IP_R2(recvbuf, count, op, comm, ierror)
+    implicit none
+    real(real32), contiguous, intent(inout)   :: recvbuf(:,:)
+    integer        :: count, ierror
+    type(MPI_OP)   :: op
+    type(MPI_COMM) :: comm
+    call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL4, op, comm, ierror)
+    if (ierror /= MPI_SUCCESS) call abort
+  end subroutine D_MPI_ALLREDUCE_REAL32_IP_R2
+  subroutine D_MPI_ALLREDUCE_REAL64_IP_R2(recvbuf, count, op, comm, ierror)
+    implicit none
+    real(real64), contiguous, intent(inout)   :: recvbuf(:,:)
+    integer        :: count, ierror
+    type(MPI_OP)   :: op
+    type(MPI_COMM) :: comm
+    call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL8, op, comm, ierror)
+    if (ierror /= MPI_SUCCESS) call abort
+  end subroutine D_MPI_ALLREDUCE_REAL64_IP_R2
 
 !>D_MPI_ALLTOALL
   subroutine D_MPI_ALLTOALL_REAL32_R1(sendbuf, sendcount, recvbuf, recvcount, comm, ierror)
@@ -427,6 +445,8 @@ contains
     call MPI_REDUCE(sendbuf, recvbuf, count, MPI_REAL8, op, root, comm, ierror)
     if (ierror /= MPI_SUCCESS) call abort
   end subroutine D_MPI_REDUCE_REAL64_R3
+  !! only root process should pass MPI_IN_PLACE
+  !! only root process should call the single-argument version
   subroutine D_MPI_REDUCE_REAL32_IP_R1(recvbuf, count, op, root, comm, ierror)
     implicit none
     real(real32), contiguous, intent(inout)   :: recvbuf(:)


### PR DESCRIPTION
...to fix error with MPI_IN_PLACE.

mpi_reduce in-place requires only the root process to pass the MPI_IN_PLACE flag. See daleslib.f90 for an example. In bulkmicrostat3, switch to allreduce for a simple fix of this issue.