### PR TITLE
OpenACC for simpleince and modsurface(lmostlocal=True)

### DIFF
--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -41,6 +41,7 @@ save
       integer ::  i2
       integer ::  j2
       integer ::  nsv = 0       !< Number of additional scalar fields
+      !$acc declare create (imax, jmax, itot, jtot)
 
       integer ::  ih=3
       integer ::  jh=3
@@ -481,7 +482,8 @@ contains
 !     tnextrestart = trestart/tres
 !     timeleft=ceiling(runtime/tres)
 
-    !$acc enter data copyin(dzf, dzh, dzfi,dzhi, zh, zf, delta, deltai)
+    !$acc enter data copyin(dzf, dzh, dzfi, dzhi, zh, zf, delta, deltai)
+    !$acc update device (imax, jmax, itot, jtot)
 
   end subroutine initglobal
 !> Clean up when leaving the run

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -32,7 +32,6 @@ module modibm
   use modglobal,    only : rd, rv, grav, ijtot
   use modprecision, only : field_r
   use modsurface,   only : psim, psih
-  use modsurfdata,  only : thvs
   use modibmdata,   only : lapply_ibm,lpoislast, lwallheat, &
                             thlwall, thlroof, qtroof, thlibm, qtibm, &
                             z0m_wall, z0h_wall
@@ -816,7 +815,7 @@ contains
     thvsl = thlroof * (1. + (rv/rd - 1.) * qtroof)
     horv2 = max(uspeed**2, 0.01)
 
-    Rib = grav / thvs * z_MO * (thv - thvsl) / horv2 !! WAAR KOMT THVS vandaan!!!!!!!!
+    Rib = grav / thvsl * z_MO * (thv - thvsl) / horv2
 
     if (Rib == 0) then
         ! Rib can be 0 if there is no surface flux

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -58,6 +58,7 @@ save
   integer  :: nprocy = 0
   integer  :: mpierr
   logical  :: periods(2) = .true.
+  !$acc declare create (myidx, myidy)
 
   real     :: CPU_program    !end time
   real     :: CPU_program0   !start time
@@ -417,7 +418,7 @@ contains
     write(cmyid,'(a,i3.3,a,i3.3)') 'x', myidx, 'y', myidy
     write(cmyidx,'(i3.3)') myidx
     write(cmyidy,'(i3.3)') myidy
-
+    
   end subroutine initmpi
 
 

--- a/src/modsimpleice.f90
+++ b/src/modsimpleice.f90
@@ -90,8 +90,6 @@ contains
     allocate(ccrz(k1),ccsz(k1),ccgz(k1))
     allocate(ccrz2(k1),ccsz2(k1),ccgz2(k1))
 
-    precep=0
-
      gamb1r=lacz_gamma(bbr+1.0)
      gambd1r=lacz_gamma(bbr+ddr+1.0)
      gamb1s=lacz_gamma(bbs+1.0)
@@ -105,6 +103,14 @@ contains
      gammadds3=lacz_gamma(3.+dds)
      gammaddg3=lacz_gamma(3.+ddg)
 
+    !$acc enter data create(qrp, qr, thlpmcr, qtpmcr, sed_qr, qr_spl, &
+    !$acc&                  ilratio, rsgratio, sgratio, lambdar, lambdas, &
+    !$acc&                  lambdag, precep, &
+    !$acc&                  ccrz, ccsz, ccgz, ccrz2, ccsz2, ccgz2)
+
+    !$acc kernels default(present)
+    precep=0
+    !$acc end kernels
   end subroutine initsimpleice
 
 !> Cleaning up after the run
@@ -115,6 +121,11 @@ contains
                              ccrz,ccsz,ccgz,&
                              ccrz2,ccsz2,ccgz2
     implicit none
+
+    !$acc exit data delete (qrp, qr, thlpmcr, qtpmcr, sed_qr, qr_spl, &
+    !$acc&                  ilratio, rsgratio, sgratio, lambdar, lambdas, &
+    !$acc&                  lambdag, precep, &
+    !$acc&                  ccrz, ccsz, ccgz, ccrz2, ccsz2, ccgz2)
     deallocate(qr,qrp,thlpmcr,qtpmcr,sed_qr,qr_spl,ilratio,rsgratio,sgratio,lambdar,lambdas,lambdag)
     deallocate(precep)
     deallocate(ccrz,ccsz,ccgz)
@@ -153,11 +164,15 @@ contains
     qrsum=0
     qrsmall=0
     ! reset microphysics tendencies
+
+    !$acc kernels default(present)
     qrp=0
     thlpmcr=0
     qtpmcr=0
+    !$acc end kernels
 
     ! Density corrected fall speed parameters, see Tomita 2008
+    !$acc parallel loop default(present)
     do k=1,k1
        ccrz(k)=ccr*(1.29/rhobf(k))**0.5
        ccsz(k)=ccs*(1.29/rhobf(k))**0.5
@@ -169,6 +184,7 @@ contains
        ccgz2(k) = gam2dg*.27*n0rg*sqrt(ccgz(k)/2.e-5)
     end do
 
+    !$acc parallel loop collapse(3) default(present) reduction(+: qrsum,qrsmall)
     do k=1,k1
     do j=2,j1
     do i=2,i1
@@ -190,6 +206,7 @@ contains
 
 
     if(l_warm) then !partitioning and determination of intercept parameter
+      !$acc parallel loop collapse(3) default(present)
       do k=1,kmax
       do j=2,j1
       do i=2,i1
@@ -198,6 +215,7 @@ contains
       enddo
       enddo
     else
+      !$acc parallel loop collapse(3) default(present)
       do k=1,kmax
       do j=2,j1
       do i=2,i1
@@ -208,6 +226,7 @@ contains
     end if
 
     if(l_warm) then !partitioning and determination of intercept parameter
+      !$acc parallel loop collapse(3) default(present)
       do k=1,kmax
       do j=2,j1
       do i=2,i1
@@ -222,6 +241,7 @@ contains
       enddo
       enddo
     elseif(l_graupel) then
+      !$acc parallel loop collapse(3) default(present)
       do k=1,kmax
       do j=2,j1
       do i=2,i1
@@ -236,6 +256,7 @@ contains
       enddo
       enddo
     else
+      !$acc parallel loop collapse(3) default(present)
       do k=1,kmax
       do j=2,j1
       do i=2,i1
@@ -310,6 +331,7 @@ contains
 
     call timer_tic(routine, 1)
     if(l_berry.eqv..true.) then ! Berry/Hsie autoconversion
+    !$acc parallel loop collapse(3) default(present) private(qll,qli,ddisp,lwc,autl,tc,times,auti,aut)
     do k=1,kmax
     do j=2,j1
     do i=2,i1
@@ -332,6 +354,7 @@ contains
       enddo
       enddo
     else ! Lin/Kessler autoconversion as in Khairoutdinov and Randall, 2006
+      !$acc parallel loop collapse(3) default(present) private(qll,qli,tc,autl,auti,aut)
       do k=1,kmax
       do j=2,j1
       do i=2,i1
@@ -370,6 +393,8 @@ contains
     integer:: i,j,k
 
     call timer_tic(routine, 1)
+    !$acc parallel loop collapse(3) default(present) private(qll,qli,qrr,qrs,qrg,&
+    !$acc&             gaccrl,gaccsl,gaccgl,gaccri,gaccsi,gaccgi,accr,accs,accg,acc)
     do k=1,kmax
     do j=2,j1
     do i=2,i1
@@ -419,6 +444,8 @@ contains
     integer:: i,j,k
 
     call timer_tic(routine, 1)
+    !$acc parallel loop collapse(3) default(present) &
+    !$acc& private(ssl,ssi,ventr,vents,ventg,thfun,evapdepr,evapdeps,evapdepg,devap)
     do k=1,kmax
     do j=2,j1
     do i=2,i1
@@ -476,8 +503,11 @@ contains
     n_spl = ceiling(wfallmax*delt/(minval(dzf)*courantp))
     dt_spl = delt/real(n_spl) !fixed time step
 
+    !$acc kernels default(present)
     sed_qr = 0 ! reset sedimentation fluxes
+    !$acc end kernels
 
+    !$acc parallel loop collapse(3) default(present) private(vtr,vts,vtg,vtf)
     do k=1,kmax
     do j=2,j1
     do i=2,i1
@@ -499,6 +529,7 @@ contains
     enddo
 
     !  advect precipitation using upwind scheme
+    !$acc parallel loop collapse(3) default(present)
     do k=1,kmax
     do j=2,j1
     do i=2,i1
@@ -512,7 +543,11 @@ contains
       DO jn = 2 , n_spl
 
         ! reset fluxes at each step of loop
+        !$acc kernels default(present)
         sed_qr = 0
+        !$acc end kernels
+
+        !$acc parallel loop collapse(3) default(present)
         do k=1,kmax
         do j=2,j1
         do i=2,i1
@@ -534,6 +569,7 @@ contains
         enddo
         enddo
 
+        !$acc parallel loop collapse(3) default(present)
         do k=1,kmax
         do j=2,j1
         do i=2,i1
@@ -547,6 +583,7 @@ contains
     ENDIF
 
     ! no thl and qt tendencies build in, implying no heat transfer between precipitation and air
+    !$acc parallel loop collapse(3) default(present)
     do k=1,kmax
     do j=2,j1
     do i=2,i1

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -101,7 +101,7 @@ contains
     use modthermodynamics, only : initthermodynamics,lqlnr, chi_half
     use modmicrophysics,   only : initmicrophysics
     use modsubgrid,        only : initsubgrid
-    use modmpi,            only : initmpi,commwrld,myid,myidx,cmyidy,nprocx,nprocy,mpierr,periods &
+    use modmpi,            only : initmpi,commwrld,myid,myidx,myidy,cmyidy,nprocx,nprocy,mpierr,periods &
                                 , D_MPI_BCAST
     use tstep,             only : inittstep
     use modchem,           only : initchem
@@ -215,6 +215,7 @@ contains
 #if defined(_OPENACC)
     call initgpu(commwrld)
 #endif
+    !$acc update device (myidx,myidy)
 
     ! Ignore user-provided nsv, we take care of it ourselves
     nsv = 0

--- a/src/modsurface.f90
+++ b/src/modsurface.f90
@@ -181,6 +181,8 @@ contains
     call D_MPI_BCAST(ltskininp                  ,            1, 0, comm3d, mpierr)
     call D_MPI_BCAST(min_horv                   ,            1, 0, comm3d, mpierr)
 
+    !$acc update device (xpatches, ypatches)
+
     if(lCO2Ags .and. (.not. lrsAgs)) then
       if(myid==0) print *,"WARNING::: You set lCO2Ags to .true., but lrsAgs to .false."
       if(myid==0) print *,"WARNING::: Since AGS does not run, lCO2Ags will be set to .false. as well."
@@ -1349,7 +1351,7 @@ contains
     if(lmostlocal) then
 
       oblavl = 0.
-
+      !$acc parallel loop collapse(2) default(present)
       do i=2,i1
         do j=2,j1
           thv     =   thl0(i,j,1)  * (1. + (rv/rd - 1.) * qt0(i,j,1))
@@ -1699,6 +1701,7 @@ contains
   end function
 
   function patchynr(ypos)
+    !$acc routine seq
     use modmpi,     only : myidy
     use modglobal,  only : jmax,jtot
     implicit none

--- a/src/modsurface.f90
+++ b/src/modsurface.f90
@@ -757,6 +757,7 @@ contains
 
     dqtdz = 0 ! need to initialize, otherwise undefined in the first call to thermodynamics, before call surface (cold start)
     ustar = 0 ! need to initialize, otherwise undefined values in the corners in the first exchange
+    obl = 1e5 ! initialize since used as starting point for iteration
 
     !$acc enter data copyin(z0m, z0h, obl, tskin, qskin, Cm, Cs, &
     !$acc&                  ustar, dudz, dvdz, thlflux, qtflux, &
@@ -911,7 +912,7 @@ contains
     integer :: Npatch(xpatches, ypatches), SNpatch(xpatches, ypatches)
 
     ! TODO: check if splitting these loops speeds things up on the GPU (async)
-    !$acc parallel loop collapse(2) default(present) 
+    !$acc parallel loop collapse(2) default(present)
     do j = 2, j1
       do i = 2, i1
         tskin(i,j) = min(max(thlflux(i,j) / (Cs(i,j) * horv(i,j)), -10.), 10.) + thl0(i,j,1)
@@ -1049,13 +1050,15 @@ contains
         end do
       end do
     end if
-    
+
+    !$acc update self(ustar)
     if ( lopenbc ) then
       call openboundary_excjs(ustar_3D, 2,i1,2,j1,1,1,1,1, &
                              (.not.lboundary(1:4)).or.lperiodic(1:4))
     else
        call excjs(ustar_3D,2,i1,2,j1,1,1,1,1)
     endif
+    !$acc update device(ustar)
   end subroutine calc_friction_velocity
 
   !> Prescribes the friction velocity \f$u_*\f$
@@ -1074,7 +1077,7 @@ contains
         end do
       end do
     else
-      !$acc parallel loop collapse(2) default(present) 
+      !$acc parallel loop collapse(2) default(present)
       do j = 2, j1
         do i = 2, i1
           ustar(i,j) = ustin
@@ -1082,13 +1085,15 @@ contains
         end do
       end do
     end if
-    
+
+   !$acc update self(ustar)
     if ( lopenbc ) then
       call openboundary_excjs(ustar_3D, 2,i1,2,j1,1,1,1,1, &
                              (.not.lboundary(1:4)).or.lperiodic(1:4))
     else
        call excjs(ustar_3D,2,i1,2,j1,1,1,1,1)
     endif
+    !$acc update device(ustar)
   end subroutine presc_friction_velocity
 
   !> Calculates the surfaces fluxes using the scalar values at the surface and
@@ -1351,6 +1356,7 @@ contains
     if(lmostlocal) then
 
       oblavl = 0.
+
       !$acc parallel loop collapse(2) default(present)
       do i=2,i1
         do j=2,j1
@@ -1366,7 +1372,7 @@ contains
             patchy = patchynr(j)
             Rib    = grav / thvs_patch(patchx,patchy) * zf(1) * (thv - thvsl) / horv2
           else
-            Rib    = grav / thvs * zf(1) * (thv - thvsl) / horv2
+            Rib    = grav / thvsl * zf(1) * (thv - thvsl) / horv2
           endif
 
           if (Rib == 0) then
@@ -1626,7 +1632,7 @@ contains
 
     return
   end function phim
-  
+
   ! stability function Phi for heat.
   function phih(zeta)
     !$acc routine seq

--- a/src/modsurfdata.f90
+++ b/src/modsurfdata.f90
@@ -236,8 +236,6 @@ SAVE
   real(field_r), allocatable :: svs   (:)              !<  Surface scalar concentration [-]
   real              :: z0    = -1             !<  Surface roughness length [m]
 
-  !$acc declare create(thvs)
-
   ! prescribed surface fluxes
   real              :: ustin  = -1            !<  Prescribed friction velocity [m/s]
   real              :: wtsurf = -1e20         !<  Prescribed kinematic temperature flux [K m/s]

--- a/src/modsurfdata.f90
+++ b/src/modsurfdata.f90
@@ -313,5 +313,5 @@ SAVE
   logical           :: ltskininp = .false.
   real, allocatable :: tskininp(:,:,:), ttskin(:)
   integer           :: nttskin
-
+  !$acc declare create(xpatches, ypatches)
 end module modsurfdata

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -192,8 +192,7 @@ contains
 !> Cleans up after the run
   subroutine exitthermodynamics
     implicit none
-    !$acc exit data delete(th0av, thv0, thetah, qth, qlh, ttab, esatltab, &
-    !$acc                  esatitab, esatmtab)
+    !$acc exit data delete(th0av, thv0, thetah, qth, qlh)
     deallocate(th0av, thv0, thetah, qth, qlh)
   end subroutine exitthermodynamics
 


### PR DESCRIPTION
Add OpenACC directives to simpleice - seems to work, not seriously tested

Also add one missing directive in modsurface - gives a weird warning
`NVFORTRAN-W-1054-Module variables used in acc routine need to be in acc declare create() `
and then fails when linking with `Undefined reference to 'modsurface_patchynr_' in 'CMakeFiles/dales.dir/modsurface.f90.o'` @CasparJungbacker any idea how to fix that? Otherwise we can live without patch support for now.