### PR TITLE
Add tendency checker

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ set( dales_srcs
 	modstat_nc.f90
 	modstat_profiles.f90
 	modstattend.f90
+	modstringutils.f90
 	modsubgrid.f90
 	modsubgriddata.f90
 	modsurface.f90

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -336,9 +336,11 @@ contains
       cval = number2string(val)
       if (.not. ieee_is_finite(val)) then
         call print_warning_non_finite(name, step, [i], cval)
-      else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
-        call print_warning_out_of_range(name, step, [i], cval, &
-                [number2string(threshold(1)), number2string(threshold(2))])
+      else if (present(threshold)) then
+        if (val < threshold(1) .or. val > threshold(2)) then
+          call print_warning_out_of_range(name, step, [i], cval, &
+                  [number2string(threshold(1)), number2string(threshold(2))])
+        end if
       end if
     end do
 
@@ -363,9 +365,11 @@ contains
       cval = number2string(val)
       if (.not. ieee_is_finite(val)) then
         call print_warning_non_finite(name, step, [i], cval)
-      else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
-        call print_warning_out_of_range(name, step, [i], cval, &
-                [number2string(threshold(1)), number2string(threshold(2))])
+      else if (present(threshold)) then
+        if (val < threshold(1) .or. val > threshold(2)) then
+          call print_warning_out_of_range(name, step, [i], cval, &
+                  [number2string(threshold(1)), number2string(threshold(2))])
+        end if
       end if
     end do
 
@@ -417,9 +421,11 @@ contains
         cval = number2string(val)
         if (.not. ieee_is_finite(val)) then
           call print_warning_non_finite(name, step, [i, j], cval)
-        else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
-          call print_warning_out_of_range(name, step, [i, j], cval, &
-                  [number2string(threshold(1)), number2string(threshold(2))])
+        else if (present(threshold)) then
+          if (val < threshold(1) .or. val > threshold(2)) then
+            call print_warning_out_of_range(name, step, [i, j], cval, &
+                    [number2string(threshold(1)), number2string(threshold(2))])
+          end if
         end if
       end do
     end do
@@ -446,9 +452,11 @@ contains
         cval = number2string(val)
         if (.not. ieee_is_finite(val)) then
           call print_warning_non_finite(name, step, [i, j], cval)
-        else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
-          call print_warning_out_of_range(name, step, [i, j], cval, &
-                  [number2string(threshold(1)), number2string(threshold(2))])
+        else if (present(threshold)) then
+          if (val < threshold(1) .or. val > threshold(2)) then
+            call print_warning_out_of_range(name, step, [i, j], cval, &
+                    [number2string(threshold(1)), number2string(threshold(2))])
+          end if
         end if
       end do
     end do
@@ -510,9 +518,11 @@ contains
           cval = number2string(val)
           if (.not. ieee_is_finite(val)) then
             call print_warning_non_finite(name, step, [i, j, k], cval)
-          else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
-            call print_warning_out_of_range(name, step, [i, j, k], cval, &
-                    [number2string(threshold(1)), number2string(threshold(2))])
+          else if (present(threshold)) then
+            if (val < threshold(1) .or. val > threshold(2)) then
+              call print_warning_out_of_range(name, step, [i, j, k], cval, &
+                      [number2string(threshold(1)), number2string(threshold(2))])
+            end if
           else
             cycle
           end if
@@ -547,9 +557,11 @@ contains
           cval = number2string(val)
           if (.not. ieee_is_finite(val)) then
             call print_warning_non_finite(name, step, [i, j, k], cval)
-          else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
-            call print_warning_out_of_range(name, step, [i, j, k], cval, &
-                    [number2string(threshold(1)), number2string(threshold(2))])
+          else if (present(threshold)) then
+            if (val < threshold(1) .or. val > threshold(2)) then
+              call print_warning_out_of_range(name, step, [i, j, k], cval, &
+                      [number2string(threshold(1)), number2string(threshold(2))])
+            end if
           else
             cycle
           end if

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -36,7 +36,7 @@ module modchecksim
                             dt_reason, ifnamopt, checknamelisterror, tres, btime, &
                             ladaptive, timee, rtimee, rk3step, rdt, fname_options
   use modfields,      only: u0, v0, w0, qt0, thl0, e120, qtp, thlp, rhobf, rhobh
-  use modsubgrid,     only: ekm
+  use modsubgriddata, only: ekm
   use modstringutils, only: number2string
   use modmpi,         only: myid, comm3d, mpierr, mpi_sum, mpi_max, D_MPI_ALLREDUCE, &
                             D_MPI_BCAST

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -289,8 +289,8 @@ contains
 
     character(len=*), intent(in) :: step
 
-    call check_array(qtp, "qtp", step, [-0.01, 0.01])
-    call check_array(thlp, "thlp", step, [-20.0, 20.0])
+    call check_array(qtp, "qtp", step, [-0.01_field_r, -0.01_field_r])
+    call check_array(thlp, "thlp", step, [-20.0_field_r, 20.0_field_r])
   
   end subroutine checktend
 

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -27,16 +27,31 @@
 !
 !
 module modchecksim
+
   use, intrinsic :: iso_fortran_env, only: real64, real32
   use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
-  use modprecision, only: field_r
-  use modglobal, only : longint, ih, jh
-  use modfields, only: u0, v0, w0, qt0, thl0, e120, qtp, thlp
+
+  use modprecision,   only: field_r
+  use modglobal,      only: longint, i1, j1,ih, jh, kmax, dtmax, dx, dy, dzf, dzh, &
+                            dt_reason, ifnamopt, checknamelisterror, tres, btime, &
+                            ladaptive, timee, rtimee, rk3step, rdt, fname_options
+  use modfields,      only: u0, v0, w0, qt0, thl0, e120, qtp, thlp, rhobf, rhobh
+  use modsubgrid,     only: ekm
   use modstringutils, only: number2string
+  use modmpi,         only: myid, comm3d, mpierr, mpi_sum, mpi_max, D_MPI_ALLREDUCE, &
+                            D_MPI_BCAST
   use modtimer
+
   implicit none
+
   private
-  public initchecksim,exitchecksim,checksim,chkdiv
+
+  character(len=*), parameter :: modname = 'modchecksim'
+
+  public :: initchecksim
+  public :: exitchecksim
+  public :: checksim
+  public :: chkdiv
 
   public :: checktend
   public :: check_array
@@ -54,139 +69,156 @@ module modchecksim
     module procedure :: check_array_3d_r8
   end interface
 
-  real    :: tcheck = 0.
-  integer(kind=longint) :: tnext = 3600.,itcheck
-  real    :: dtmn =0.,ndt =0.
+  real(field_r) :: &
+    tcheck = 0,    &
+    dtmn = 0,      &
+    ndt = 0
+
+  integer(longint) :: &
+    tnext = 3600,     &
+    itcheck
 
   ! explanations for dt_limit, determined in tstep_update()
-  character (len=15) :: dt_reasons(0:5) = [character(len=15):: "initial step", "timee", "dt_lim" , "idtmax", "velocity", "diffusion"]
+  character (len=15) :: dt_reasons(0:5) = [character(len=15) :: &
+    "initial step", "timee", "dt_lim" , "idtmax", "velocity", "diffusion"]
 
   logical :: lchecktend
   logical :: lstop
 
-  save
-    real, public, allocatable, dimension (:) :: courxl
-    real, public, allocatable, dimension (:) :: courx
-    real, public, allocatable, dimension (:) :: couryl
-    real, public, allocatable, dimension (:) :: coury
-    real, public, allocatable, dimension (:) :: courzl
-    real, public, allocatable, dimension (:) :: courz
-    real, public, allocatable, dimension (:) :: courtotl
-    real, public, allocatable, dimension (:) :: courtot
-    real, public, allocatable, dimension (:) :: peclettotl
-    real, public, allocatable, dimension (:) :: peclettot
+  real, public, allocatable, dimension (:) :: courxl
+  real, public, allocatable, dimension (:) :: courx
+  real, public, allocatable, dimension (:) :: couryl
+  real, public, allocatable, dimension (:) :: coury
+  real, public, allocatable, dimension (:) :: courzl
+  real, public, allocatable, dimension (:) :: courz
+  real, public, allocatable, dimension (:) :: courtotl
+  real, public, allocatable, dimension (:) :: courtot
+  real, public, allocatable, dimension (:) :: peclettotl
+  real, public, allocatable, dimension (:) :: peclettot
 
 contains
-!> Initializing Checksim. Read out the namelist, initializing the variables
-  subroutine initchecksim
-    use modglobal, only : kmax,ifnamopt,fname_options,dtmax,ladaptive,btime,tres,checknamelisterror
-    use modmpi,    only : myid,comm3d,mpierr,D_MPI_BCAST
-    implicit none
+  
+  !> Read checksim namelist.
+  subroutine checksim_read_namelist(nml_filename)
+
+    character(len=*), intent(in) :: nml_filename
+
     integer :: ierr
 
-    namelist/NAMCHECKSIM/ &
-    tcheck, lchecktend, lstop
+    namelist /NAMCHECKSIM/ tcheck, lchecktend, lstop
 
-    call timer_tic('modchecksim/initchecksim', 0)
-
-    if(myid==0)then
-      open(ifnamopt,file=fname_options,status='old',iostat=ierr)
-      read (ifnamopt,NAMCHECKSIM,iostat=ierr)
+    if (myid == 0) then
+      open(ifnamopt, file=nml_filename, status='old', iostat=ierr)
+      read(ifnamopt, NAMCHECKSIM, iostat=ierr)
       call checknamelisterror(ierr, ifnamopt, 'NAMCHECKSIM')
-      write(6 ,NAMCHECKSIM)
+      write(6, NAMCHECKSIM) ! Maybe write to separate file, for cleaner terminal
       close(ifnamopt)
-
-      if (.not. ladaptive .and. tcheck < dtmax) then
-        tcheck = dtmax
-      end if
     end if
 
-    call D_MPI_BCAST(tcheck     ,1,0,comm3d,mpierr)
-    call D_MPI_BCAST(lchecktend     ,1,0,comm3d,mpierr)
-    call D_MPI_BCAST(lstop     ,1,0,comm3d,mpierr)
-    itcheck = floor(tcheck/tres)
-    tnext = itcheck+btime
+    call D_MPI_BCAST(tcheck, 1, 0, comm3d, mpierr)
+    call D_MPI_BCAST(lchecktend, 1, 0, comm3d, mpierr)
+    call D_MPI_BCAST(lstop, 1, 0, comm3d, mpierr)
 
-    allocate(courxl(kmax))
-    allocate(courx(kmax))
-    allocate(couryl(kmax))
-    allocate(coury(kmax))
-    allocate(courzl(kmax))
-    allocate(courz(kmax))
-    allocate(courtotl(kmax))
-    allocate(courtot(kmax))
-    allocate(peclettotl(kmax))
-    allocate(peclettot(kmax))
+  end subroutine checksim_read_namelist
+
+  !> Initialize checksim variables.
+  subroutine initchecksim
+
+    character(len=*), parameter :: routine = modname//'/initchecksim'
+
+    integer :: ierr
+
+    call timer_tic(routine, 0)
+
+    call checksim_read_namelist(fname_options)
+
+    if (.not. ladaptive .and. tcheck < dtmax) then
+      tcheck = dtmax
+    end if
+
+    itcheck = floor(tcheck / tres)
+    tnext = itcheck + btime
+
+    allocate(courx(kmax), courxl(kmax), coury(kmax), couryl(kmax), courz(kmax), &
+             courzl(kmax), courtot(kmax), courtotl(kmax), peclettot(kmax), &
+             peclettotl(kmax))
 
     !$acc enter data create(courxl, couryl, courzl, courtotl, peclettotl)
 
-    call timer_toc('modchecksim/initchecksim')
+    call timer_toc(routine)
 
   end subroutine initchecksim
 
-!> Exiting Checksim: clean out variables
+  !> Deallocate checksim arrays.
   subroutine exitchecksim
 
     !$acc exit data delete(courxl, couryl, courzl, courtotl, peclettotl)
 
-    deallocate(courxl)
-    deallocate(courx)
-    deallocate(couryl)
-    deallocate(coury)
-    deallocate(courzl)
-    deallocate(courz)
-    deallocate(courtotl)
-    deallocate(courtot)
-    deallocate(peclettotl)
-    deallocate(peclettot)
+    deallocate(courx, courxl, coury, couryl, courz, courzl, courtot, courtotl, &
+               peclettot, peclettotl)
+
   end subroutine exitchecksim
 
-!>Run checksim. Timekeeping, and output
+  !> Run checksim. Timekeeping, and output
   subroutine checksim
-    use modglobal, only : timee,rtimee, rk3step, rdt
-    use modmpi,    only : myid
-    implicit none
-    character(20) :: timeday
-    if (timee ==0) return
-    if (rk3step/=3) return
-    dtmn = dtmn +rdt; ndt =ndt+1.
-    if(timee<tnext) return
+    
+    character(len=*), parameter :: routine = modname//'/checksim'
+
+    character(len=20) :: timeday
+
+    if (timee == 0) return
+    if (rk3step /= 3) return
+
+    dtmn = dtmn + rdt
+    ndt = ndt + 1
+
+    if (timee < tnext) return
+
     call timer_tic('modchecksim/checksim', 0)
+
     tnext = tnext+itcheck
     dtmn  = dtmn / ndt
-    if (myid==0) then
+
+    if (myid == 0) then
       call date_and_time(time=timeday)
       write (*,*) '================================================================='
-      write (*,'(7A,F11.2,A,F9.4)') 'Time of Day: ', timeday(1:2), ':', timeday(3:4), ':', timeday(5:10),' Time of Simulation: ', rtimee, '    dt: ',dtmn
+      write (*,'(7A,F11.2,A,F9.4)') 'Time of Day: ', timeday(1:2), ':', &
+        timeday(3:4), ':', timeday(5:10),' Time of Simulation: ', &
+        rtimee, '    dt: ',dtmn
     end if
+
     call calccourantandpeclet
     call chkdiv
+
     dtmn  = 0.
     ndt   = 0.
 
     call timer_toc('modchecksim/checksim')
 
   end subroutine checksim
-!>      Calculates the courant number as in max(w)*deltat/deltaz
-!>      and peclet number as max(ekm) *deltat/deltax**2
+
+  !> Calculates the courant number as in max(w)*deltat/deltaz
+  !! and peclet number as max(ekm) *deltat/deltax**2
   subroutine calccourantandpeclet
-    use modglobal, only : i1,j1,kmax,dx,dy,dzh
-    use modfields, only : u0,v0,w0
-    use modsubgrid,only : ekm
-    use modmpi,    only : myid,comm3d,mpierr,mpi_max, D_MPI_ALLREDUCE
-    implicit none
 
-    integer :: i, j, k
-    real(field_r)    :: velx_max, vely_max, velz_max, velmag_max, ekm_max
+    integer       :: i, j, k
+    real(field_r) :: &
+      velx_max,      &
+      vely_max,      &
+      velz_max,      &
+      velmag_max,    &
+      ekm_max
 
-    !$acc parallel loop gang default(present) private(velx_max, vely_max, velz_max, velmag_max, ekm_max)
+    !$acc parallel loop gang default(present) &
+    !$acc private(velx_max, vely_max, velz_max, velmag_max, ekm_max)
     do k = 1, kmax
-      velx_max = 0.0
-      vely_max = 0.0
-      velz_max = 0.0
-      velmag_max = 0.0
-      ekm_max = 0.0
-      !$acc loop collapse(2) reduction(max:velx_max, vely_max, velz_max, velmag_max, ekm_max)
+      velx_max = 0
+      vely_max = 0
+      velz_max = 0
+      velmag_max = 0
+      ekm_max = 0
+      !$acc loop collapse(2) &
+      !$acc reduction(max:velx_max, vely_max, velz_max, velmag_max, ekm_max)
       do j = 2, j1
         do i = 2, i1
           velx_max = max(velx_max, abs(u0(i,j,k)))
@@ -204,34 +236,35 @@ contains
       courtotl(k)=velmag_max*dtmn*dtmn
       peclettotl(k)=ekm_max*dtmn/min(dzh(k),dx,dy)**2
     end do
+
     !$acc update self(courxl, couryl, courzl, courtotl, peclettotl)
 
-    call D_MPI_ALLREDUCE(courxl  ,courx  ,kmax,MPI_MAX,comm3d,mpierr)
-    call D_MPI_ALLREDUCE(couryl  ,coury  ,kmax,MPI_MAX,comm3d,mpierr)
-    call D_MPI_ALLREDUCE(courzl  ,courz  ,kmax,MPI_MAX,comm3d,mpierr)
-    call D_MPI_ALLREDUCE(courtotl,courtot,kmax,MPI_MAX,comm3d,mpierr)
-    call D_MPI_ALLREDUCE(peclettotl,peclettot,kmax,MPI_MAX,comm3d,mpierr)
+    call D_MPI_ALLREDUCE(courxl, courx, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(couryl, coury, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(courzl, courz, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(courtotl, courtot, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(peclettotl, peclettot, kmax, MPI_MAX, comm3d, mpierr)
 
-    if (myid==0) then
-      write(*,'(A,3ES10.2,I5,ES10.2,I5)') 'Courant numbers (x,y,z,tot):',&
-      maxval(courx(1:kmax)),maxval(coury(1:kmax)),maxval(courz(1:kmax)),maxloc(courz(1:kmax)),sqrt(maxval(courtot(1:kmax))),maxloc(courtot(1:kmax))
-      write(6,'(A,ES10.2,I5)') 'Cell Peclet number:',maxval(peclettot(1:kmax)),maxloc(peclettot(1:kmax))
+    if (myid == 0) then
+      write(*,'(A,3ES10.2,I5,ES10.2,I5)') 'Courant numbers (x,y,z,tot):', &
+        maxval(courx(:)), maxval(coury(:)), maxval(courz(:)), maxloc(courz(:)), &
+        sqrt(maxval(courtot(:))), maxloc(courtot(:))
+      write(6,'(A,ES10.2,I5)') 'Cell Peclet number:', &
+        maxval(peclettot(:)), maxloc(peclettot(:))
     end if
 
-    return
   end subroutine calccourantandpeclet
 
-!> Checks local and total divergence
+  !> Checks local and total divergence.
   subroutine chkdiv
 
-    use modglobal, only : i1,j1,kmax,dx,dy,dzf,dt_reason
-    use modfields, only : u0,v0,w0,rhobf,rhobh
-    use modmpi,    only : myid,comm3d,mpi_sum,mpi_max,mpierr, D_MPI_ALLREDUCE
-    implicit none
-
-    real div, divmax, divtot
-    real divmaxl, divtotl
-    integer i, j, k
+    integer       :: i, j, k
+    real(field_r) :: &
+      div,           &
+      divmax,        &
+      divtot,        &
+      divmaxl,       &
+      divtotl
 
     divmax = 0.
     divtot = 0.
@@ -239,30 +272,27 @@ contains
     divtotl= 0.
 
     !$acc parallel loop collapse(3) default(present) private(div, divmaxl, divtotl) &
-    !$acc& reduction(max:divmaxl) reduction(+:divtotl)
+    !$acc reduction(max:divmaxl) reduction(+:divtotl)
     do k=1,kmax
       do j=2,j1
         do i=2,i1
-           div = &
-                    rhobf(k) * (u0(i+1,j,k) - u0(i,j,k) )/dx + &
-                    rhobf(k) * (v0(i,j+1,k) - v0(i,j,k) )/dy + &
-                    (rhobh(k+1)*w0(i,j,k+1) - rhobh(k)*w0(i,j,k) )/dzf(k)
+          div = rhobf(k) * (u0(i+1,j,k) - u0(i,j,k) )/dx + &
+                rhobf(k) * (v0(i,j+1,k) - v0(i,j,k) )/dy + &
+                (rhobh(k+1)*w0(i,j,k+1) - rhobh(k)*w0(i,j,k) )/dzf(k)
           divmaxl = max(divmaxl,abs(div))
           divtotl = divtotl + div*dx*dy*dzf(k)
         end do
       end do
     end do
 
-    call D_MPI_ALLREDUCE(divtotl, divtot, 1,     &
-                          MPI_SUM, comm3d,mpierr)
-    call D_MPI_ALLREDUCE(divmaxl, divmax, 1,     &
-                          MPI_MAX, comm3d,mpierr)
+    call D_MPI_ALLREDUCE(divtotl, divtot, 1, MPI_SUM, comm3d,mpierr)
+    call D_MPI_ALLREDUCE(divmaxl, divmax, 1, MPI_MAX, comm3d,mpierr)
 
-    if(myid==0)then
-      write(6 ,'(A,2ES11.2,A,A)')'divmax, divtot = ', divmax, divtot,  '       dt limited by ', dt_reasons(dt_reason)
+    if (myid == 0) then
+      write(6 ,'(A,2ES11.2,A,A)')'divmax, divtot = ', divmax, divtot,  &
+        '       dt limited by ', dt_reasons(dt_reason)
    end if
 
-   return
   end subroutine chkdiv
 
   !> Check tendencies of various prognostic variables.

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -259,7 +259,7 @@ contains
     divmax = 0.
     divtot = 0.
 
-    !$acc parallel loop collapse(3) default(present) private(div, divmaxl, divtotl) &
+    !$acc parallel loop collapse(3) default(present) private(div) &
     !$acc reduction(max:divmaxl) reduction(+:divtotl)
     do k=1,kmax
       do j=2,j1

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -260,7 +260,7 @@ contains
     divtot = 0.
 
     !$acc parallel loop collapse(3) default(present) private(div) &
-    !$acc reduction(max:divmaxl) reduction(+:divtotl)
+    !$acc reduction(max:divmax) reduction(+:divtot)
     do k=1,kmax
       do j=2,j1
         do i=2,i1

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -27,12 +27,32 @@
 !
 !
 module modchecksim
+  use, intrinsic :: iso_fortran_env, only: real64, real32
+  use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
   use modprecision, only: field_r
-  use modglobal, only : longint
+  use modglobal, only : longint, ih, jh
+  use modfields, only: u0, v0, w0, qt0, thl0, e120, qtp, thlp
+  use modstringutils, only: number2string
   use modtimer
   implicit none
   private
   public initchecksim,exitchecksim,checksim,chkdiv
+
+  public :: checktend
+  public :: check_array
+  public :: lchecktend
+
+  interface check_array !< Check array for invalid values and/or values outside of a given range.
+    module procedure :: check_array_1d_int
+    module procedure :: check_array_1d_r4
+    module procedure :: check_array_1d_r8
+    module procedure :: check_array_2d_int
+    module procedure :: check_array_2d_r4
+    module procedure :: check_array_2d_r8
+    module procedure :: check_array_3d_int
+    module procedure :: check_array_3d_r4
+    module procedure :: check_array_3d_r8
+  end interface
 
   real    :: tcheck = 0.
   integer(kind=longint) :: tnext = 3600.,itcheck
@@ -40,6 +60,9 @@ module modchecksim
 
   ! explanations for dt_limit, determined in tstep_update()
   character (len=15) :: dt_reasons(0:5) = [character(len=15):: "initial step", "timee", "dt_lim" , "idtmax", "velocity", "diffusion"]
+
+  logical :: lchecktend
+  logical :: lstop
 
   save
     real, public, allocatable, dimension (:) :: courxl
@@ -62,7 +85,7 @@ contains
     integer :: ierr
 
     namelist/NAMCHECKSIM/ &
-    tcheck
+    tcheck, lchecktend, lstop
 
     call timer_tic('modchecksim/initchecksim', 0)
 
@@ -79,6 +102,8 @@ contains
     end if
 
     call D_MPI_BCAST(tcheck     ,1,0,comm3d,mpierr)
+    call D_MPI_BCAST(lchecktend     ,1,0,comm3d,mpierr)
+    call D_MPI_BCAST(lstop     ,1,0,comm3d,mpierr)
     itcheck = floor(tcheck/tres)
     tnext = itcheck+btime
 
@@ -239,5 +264,339 @@ contains
 
    return
   end subroutine chkdiv
+
+  !> Check tendencies of various prognostic variables.
+  subroutine checktend(step)
+
+    character(len=*), intent(in) :: step
+
+    call check_array(qtp, "qtp", step, [-0.01, 0.01])
+    call check_array(thlp, "thlp", step, [-20.0, 20.0])
+  
+  end subroutine checktend
+
+  subroutine check_array_1d_int(array, name, step, threshold, lacc)
+
+    integer,          intent(in) :: array(:), threshold(2)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    logical, intent(in), optional :: lacc
+
+    integer           :: i
+    integer           :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do i = 1, size(array, dim=1)
+      val = array(i)
+      cval = number2string(val)
+      if ((val < threshold(1) .or. val > threshold(2))) then
+        call print_warning_out_of_range(name, step, [i], cval, &
+                [number2string(threshold(1)), number2string(threshold(2))])
+      end if
+    end do
+
+  end subroutine check_array_1d_int
+
+  subroutine check_array_1d_r4(array, name, step, threshold, lacc)
+
+    real(real32),     intent(in) :: array(:)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    real(real32), intent(in), optional :: threshold(2)
+    logical,      intent(in), optional :: lacc
+
+    integer           :: i
+    real(real32)      :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do i = 1, size(array, dim=1)
+      val = array(i)
+      cval = number2string(val)
+      if (.not. ieee_is_finite(val)) then
+        call print_warning_non_finite(name, step, [i], cval)
+      else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
+        call print_warning_out_of_range(name, step, [i], cval, &
+                [number2string(threshold(1)), number2string(threshold(2))])
+      end if
+    end do
+
+  end subroutine check_array_1d_r4
+
+  subroutine check_array_1d_r8(array, name, step, threshold, lacc)
+
+    real(real64),     intent(in) :: array(:)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    real(real64), intent(in), optional :: threshold(2)
+    logical,      intent(in), optional :: lacc
+
+    integer           :: i
+    real(real64)      :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do i = 1, size(array, dim=1)
+      val = array(i)
+      cval = number2string(val)
+      if (.not. ieee_is_finite(val)) then
+        call print_warning_non_finite(name, step, [i], cval)
+      else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
+        call print_warning_out_of_range(name, step, [i], cval, &
+                [number2string(threshold(1)), number2string(threshold(2))])
+      end if
+    end do
+
+  end subroutine check_array_1d_r8
+
+  subroutine check_array_2d_int(array, name, step, threshold, lacc)
+
+    integer,          intent(in) :: array(:,:), threshold(2)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    logical, intent(in), optional :: lacc
+
+    integer           :: i, j
+    integer           :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do j = 1, size(array, dim=2)
+      do i = 1, size(array, dim=1)
+        val = array(i,j)
+        cval = number2string(val)
+        if ((val < threshold(1) .or. val > threshold(2))) then
+          call print_warning_out_of_range(name, step, [i, j], cval, &
+                  [number2string(threshold(1)), number2string(threshold(2))])
+        end if
+      end do
+    end do
+
+  end subroutine check_array_2d_int
+
+  subroutine check_array_2d_r4(array, name, step, threshold, lacc)
+
+    real(real32),     intent(in) :: array(:,:)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    real(real32), intent(in), optional :: threshold(2)
+    logical,      intent(in), optional :: lacc
+
+    integer           :: i, j
+    real(real32)      :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do j = 1, size(array, dim=2)
+      do i = 1, size(array, dim=1)
+        val = array(i,j)
+        cval = number2string(val)
+        if (.not. ieee_is_finite(val)) then
+          call print_warning_non_finite(name, step, [i, j], cval)
+        else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
+          call print_warning_out_of_range(name, step, [i, j], cval, &
+                  [number2string(threshold(1)), number2string(threshold(2))])
+        end if
+      end do
+    end do
+
+  end subroutine check_array_2d_r4
+
+  subroutine check_array_2d_r8(array, name, step, threshold, lacc)
+
+    real(real64),     intent(in) :: array(:,:)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    real(real64), intent(in), optional :: threshold(2)
+    logical,      intent(in), optional :: lacc
+
+    integer           :: i, j
+    real(real64)      :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do j = 1, size(array, dim=2)
+      do i = 1, size(array, dim=1)
+        val = array(i,j)
+        cval = number2string(val)
+        if (.not. ieee_is_finite(val)) then
+          call print_warning_non_finite(name, step, [i, j], cval)
+        else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
+          call print_warning_out_of_range(name, step, [i, j], cval, &
+                  [number2string(threshold(1)), number2string(threshold(2))])
+        end if
+      end do
+    end do
+
+  end subroutine check_array_2d_r8
+
+  subroutine check_array_3d_int(array, name, step, threshold, lacc)
+
+    integer,          intent(in) :: array(:,:,:), threshold(2)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    logical, intent(in), optional :: lacc
+
+    integer           :: i, j, k
+    integer           :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do k = 1, size(array, dim=3)
+      do j = 1, size(array, dim=2)
+        do i = 1, size(array, dim=1)
+          val = array(i,j,k)
+          cval = number2string(val)
+          if ((val < threshold(1) .or. val > threshold(2))) then
+            call print_warning_out_of_range(name, step, [i, j, k], cval, &
+                    [number2string(threshold(1)), number2string(threshold(2))])
+          else
+            cycle
+          end if
+          if (lstop) then
+            call dump_state([i,j,k])
+            error stop
+          end if
+        end do
+      end do
+    end do
+
+  end subroutine check_array_3d_int
+
+  subroutine check_array_3d_r4(array, name, step, threshold, lacc)
+
+    real(real32),     intent(in) :: array(:,:,:)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    real(real32), intent(in), optional :: threshold(2)
+    logical,      intent(in), optional :: lacc
+
+    integer           :: i, j, k
+    real(real32)      :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do k = 1, size(array, dim=3)
+      do j = 1, size(array, dim=2)
+        do i = 1, size(array, dim=1)
+          val = array(i,j,k)
+          cval = number2string(val)
+          if (.not. ieee_is_finite(val)) then
+            call print_warning_non_finite(name, step, [i, j, k], cval)
+          else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
+            call print_warning_out_of_range(name, step, [i, j, k], cval, &
+                    [number2string(threshold(1)), number2string(threshold(2))])
+          else
+            cycle
+          end if
+          if (lstop) then
+            call dump_state([i-ih+1,j-jh+1,k])
+            error stop
+          end if
+        end do
+      end do
+    end do
+
+  end subroutine check_array_3d_r4
+
+  subroutine check_array_3d_r8(array, name, step, threshold, lacc)
+
+    real(real64),     intent(in) :: array(:,:,:)
+    character(len=*), intent(in) :: name
+    character(len=*), intent(in) :: step
+
+    real(real64), intent(in), optional :: threshold(2)
+    logical,      intent(in), optional :: lacc
+
+    integer      :: i, j, k
+    real(real64) :: val
+    character(len=32) :: cloc
+    character(len=11) :: cval
+
+    do k = 1, size(array, dim=3)
+      do j = 1, size(array, dim=2)
+        do i = 1, size(array, dim=1)
+          val = array(i,j,k)
+          cval = number2string(val)
+          if (.not. ieee_is_finite(val)) then
+            call print_warning_non_finite(name, step, [i, j, k], cval)
+          else if (present(threshold) .and. (val < threshold(1) .or. val > threshold(2))) then
+            call print_warning_out_of_range(name, step, [i, j, k], cval, &
+                    [number2string(threshold(1)), number2string(threshold(2))])
+          else
+            cycle
+          end if
+          if (lstop) then
+            call dump_state([i-ih+1,j-jh+1,k])
+            error stop
+          end if
+        end do
+      end do
+    end do
+
+  end subroutine check_array_3d_r8
+
+  !> Prints non-finite warning (Inf, NaN) to stderr.
+  subroutine print_warning_non_finite(name, step, loc, cval)
+
+    character(len=*), intent(in) :: name, step, cval
+    integer,          intent(in) :: loc(:)
+
+    character(len=128) :: cloc
+
+    write(cloc, "(*(g0,:,','))") loc
+    write(0,'(*(a))') &
+      'modchecktend: Invalid value found in array: ', trim(name), '  [step=', &
+      trim(step), ']  [location=', trim(cloc), ']  [value=', trim(cval), ']'
+
+  end subroutine print_warning_non_finite
+
+  !> Prints out of range warning to stderr.
+  subroutine print_warning_out_of_range(name, step, loc, cval, cthreshold)
+
+    character(len=*), intent(in) :: name, step, cval, cthreshold(2)
+    integer,          intent(in) :: loc(:)
+
+    character(len=128) :: cloc
+
+    write(cloc, "(*(g0,:,','))") loc
+    write(0,'(13a)') &
+      'modchecktend: Value outside of valid range found in array: ', trim(name), &
+      '  [step=', trim(step), ']  [location=', trim(cloc), ']  [value=', trim(cval), ']&
+      &  [min,max=', trim(cthreshold(1)), ',', trim(cthreshold(2)), ']'
+
+  end subroutine print_warning_out_of_range
+
+  !> Dumps values of prognostic variables at specified location.
+  !!
+  !! @param[in] loc (i,j,k) location to print variables for. 
+  subroutine dump_state(loc)
+
+    integer, intent(in) :: loc(3)
+
+    integer :: i, j, k
+
+    i = loc(1)
+    j = loc(2)
+    k = loc(3)
+
+    write(0, '(7(a,/))')"Prognostic variables:", &
+      & "u   = "//number2string(u0(i,j,k)), &
+      & "v   = "//number2string(v0(i,j,k)), &
+      & "w   = "//number2string(w0(i,j,k)), &
+      & "qt  = "//number2string(qt0(i,j,k)), &
+      & "thl = "//number2string(thl0(i,j,k)), &
+      & "e12 = "//number2string(e120(i,j,k))
+
+  end subroutine dump_state
 
 end module modchecksim

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -48,6 +48,7 @@ module modchecksim
 
   character(len=*), parameter :: modname = 'modchecksim'
 
+  public :: checksim_read_namelist
   public :: initchecksim
   public :: exitchecksim
   public :: checksim
@@ -125,8 +126,6 @@ contains
     integer :: ierr
 
     call timer_tic(routine, 0)
-
-    call checksim_read_namelist(fname_options)
 
     if (.not. ladaptive .and. tcheck < dtmax) then
       tcheck = dtmax

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -85,16 +85,12 @@ module modchecksim
   logical :: lchecktend
   logical :: lstop
 
-  real, public, allocatable, dimension (:) :: courxl
-  real, public, allocatable, dimension (:) :: courx
-  real, public, allocatable, dimension (:) :: couryl
-  real, public, allocatable, dimension (:) :: coury
-  real, public, allocatable, dimension (:) :: courzl
-  real, public, allocatable, dimension (:) :: courz
-  real, public, allocatable, dimension (:) :: courtotl
-  real, public, allocatable, dimension (:) :: courtot
-  real, public, allocatable, dimension (:) :: peclettotl
-  real, public, allocatable, dimension (:) :: peclettot
+  real(field_r), allocatable :: &
+    courx(:),                   &
+    coury(:),                   &
+    courz(:),                   &
+    courtot(:),                 &
+    peclettot(:)
 
 contains
   
@@ -139,11 +135,9 @@ contains
     itcheck = floor(tcheck / tres)
     tnext = itcheck + btime
 
-    allocate(courx(kmax), courxl(kmax), coury(kmax), couryl(kmax), courz(kmax), &
-             courzl(kmax), courtot(kmax), courtotl(kmax), peclettot(kmax), &
-             peclettotl(kmax))
+    allocate(courx(kmax), coury(kmax), courz(kmax), courtot(kmax), peclettot(kmax))
 
-    !$acc enter data create(courxl, couryl, courzl, courtotl, peclettotl)
+    !$acc enter data create(courx, coury, courz, courtot, peclettot)
 
     call timer_toc(routine)
 
@@ -152,10 +146,9 @@ contains
   !> Deallocate checksim arrays.
   subroutine exitchecksim
 
-    !$acc exit data delete(courxl, couryl, courzl, courtotl, peclettotl)
+    !$acc exit data delete(courx, coury, courz, courtot, peclettot)
 
-    deallocate(courx, courxl, coury, couryl, courz, courzl, courtot, courtotl, &
-               peclettot, peclettotl)
+    deallocate(courx, coury, courz, courtot, peclettot)
 
   end subroutine exitchecksim
 
@@ -230,20 +223,20 @@ contains
           ekm_max = max(ekm_max, ekm(i,j,k))
         enddo
       enddo
-      courxl(k)=velx_max*dtmn/dx
-      couryl(k)=vely_max*dtmn/dy
-      courzl(k)=velz_max*dtmn/dzh(k)
-      courtotl(k)=velmag_max*dtmn*dtmn
-      peclettotl(k)=ekm_max*dtmn/min(dzh(k),dx,dy)**2
+      courx(k)=velx_max*dtmn/dx
+      coury(k)=vely_max*dtmn/dy
+      courz(k)=velz_max*dtmn/dzh(k)
+      courtot(k)=velmag_max*dtmn*dtmn
+      peclettot(k)=ekm_max*dtmn/min(dzh(k),dx,dy)**2
     end do
 
-    !$acc update self(courxl, couryl, courzl, courtotl, peclettotl)
+    !$acc update self(courx, coury, courz, courtot, peclettot)
 
-    call D_MPI_ALLREDUCE(courxl, courx, kmax, MPI_MAX, comm3d, mpierr)
-    call D_MPI_ALLREDUCE(couryl, coury, kmax, MPI_MAX, comm3d, mpierr)
-    call D_MPI_ALLREDUCE(courzl, courz, kmax, MPI_MAX, comm3d, mpierr)
-    call D_MPI_ALLREDUCE(courtotl, courtot, kmax, MPI_MAX, comm3d, mpierr)
-    call D_MPI_ALLREDUCE(peclettotl, peclettot, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(courx, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(coury, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(courz, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(courtot, kmax, MPI_MAX, comm3d, mpierr)
+    call D_MPI_ALLREDUCE(peclettot, kmax, MPI_MAX, comm3d, mpierr)
 
     if (myid == 0) then
       write(*,'(A,3ES10.2,I5,ES10.2,I5)') 'Courant numbers (x,y,z,tot):', &
@@ -262,14 +255,10 @@ contains
     real(field_r) :: &
       div,           &
       divmax,        &
-      divtot,        &
-      divmaxl,       &
-      divtotl
+      divtot
 
     divmax = 0.
     divtot = 0.
-    divmaxl= 0.
-    divtotl= 0.
 
     !$acc parallel loop collapse(3) default(present) private(div, divmaxl, divtotl) &
     !$acc reduction(max:divmaxl) reduction(+:divtotl)
@@ -279,14 +268,14 @@ contains
           div = rhobf(k) * (u0(i+1,j,k) - u0(i,j,k) )/dx + &
                 rhobf(k) * (v0(i,j+1,k) - v0(i,j,k) )/dy + &
                 (rhobh(k+1)*w0(i,j,k+1) - rhobh(k)*w0(i,j,k) )/dzf(k)
-          divmaxl = max(divmaxl,abs(div))
-          divtotl = divtotl + div*dx*dy*dzf(k)
+          divmax = max(divmax,abs(div))
+          divtot = divtot + div*dx*dy*dzf(k)
         end do
       end do
     end do
 
-    call D_MPI_ALLREDUCE(divtotl, divtot, 1, MPI_SUM, comm3d,mpierr)
-    call D_MPI_ALLREDUCE(divmaxl, divmax, 1, MPI_MAX, comm3d,mpierr)
+    call D_MPI_ALLREDUCE(divtot, 1, MPI_SUM, comm3d,mpierr)
+    call D_MPI_ALLREDUCE(divmax, 1, MPI_MAX, comm3d,mpierr)
 
     if (myid == 0) then
       write(6 ,'(A,2ES11.2,A,A)')'divmax, divtot = ', divmax, divtot,  &

--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -62,7 +62,6 @@ contains
     use modthermodynamics, only: th0av, thv0, thetah, qth, qlh
     use modboundary, only: tsc
     use modmicrodata, only: precep, thlpmcr, qtpmcr
-    use modchecksim, only: courxl, couryl, courzl, courtotl, peclettotl
     use modibm,      only: fluid_mask, iobst, ixw_p, ixw_m, iyw_p, iyw_m, izw_p
 
     implicit none
@@ -135,7 +134,6 @@ contains
     use modthermodynamics, only: th0av, thv0, thetah, qth, qlh
     use modboundary, only: tsc
     use modmicrodata, only: precep, thlpmcr, qtpmcr
-    use modchecksim, only: courxl, couryl, courzl, courtotl, peclettotl
     use modibm,      only: fluid_mask, iobst, ixw_p, ixw_m, iyw_p, iyw_m, izw_p
 
     implicit none

--- a/src/modmpi.f90
+++ b/src/modmpi.f90
@@ -153,6 +153,9 @@ interface D_MPI_ISEND
     procedure :: D_MPI_ALLREDUCE_REAL64_R3
     procedure :: D_MPI_ALLREDUCE_INT32_R1
     procedure :: D_MPI_ALLREDUCE_INT32_R2
+    procedure :: D_MPI_ALLREDUCE_REAL32_IP_S
+    procedure :: D_MPI_ALLREDUCE_REAL64_IP_S
+    procedure :: D_MPI_ALLREDUCE_INT32_IP_S
     procedure :: D_MPI_ALLREDUCE_REAL32_IP
     procedure :: D_MPI_ALLREDUCE_REAL64_IP
     procedure :: D_MPI_ALLREDUCE_REAL32_IP_R2

--- a/src/modmpiinterface.f90
+++ b/src/modmpiinterface.f90
@@ -335,6 +335,33 @@ contains
     call MPI_ALLREDUCE(sendbuf, recvbuf, count, MPI_INTEGER4, op, comm, ierror)
     if (ierror /= MPI_SUCCESS) call abort
   end subroutine D_MPI_ALLREDUCE_INT32_R1
+  subroutine D_MPI_ALLREDUCE_REAL32_IP_S(recvbuf, count, op, comm, ierror)
+    implicit none
+    real(real32), intent(inout)   :: recvbuf
+    integer        :: count, ierror
+    type(MPI_OP)   :: op
+    type(MPI_COMM) :: comm
+    call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL4, op, comm, ierror)
+    if (ierror /= MPI_SUCCESS) call abort
+  end subroutine D_MPI_ALLREDUCE_REAL32_IP_S
+  subroutine D_MPI_ALLREDUCE_REAL64_IP_S(recvbuf, count, op, comm, ierror)
+    implicit none
+    real(real64), intent(inout)   :: recvbuf
+    integer        :: count, ierror
+    type(MPI_OP)   :: op
+    type(MPI_COMM) :: comm
+    call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_REAL8, op, comm, ierror)
+    if (ierror /= MPI_SUCCESS) call abort
+  end subroutine D_MPI_ALLREDUCE_REAL64_IP_S
+  subroutine D_MPI_ALLREDUCE_INT32_IP_S(recvbuf, count, op, comm, ierror)
+    implicit none
+    integer(int32), intent(inout) :: recvbuf
+    integer        :: count, ierror
+    type(MPI_OP)   :: op
+    type(MPI_COMM) :: comm
+    call MPI_ALLREDUCE(MPI_IN_PLACE, recvbuf, count, MPI_INTEGER4, op, comm, ierror)
+    if (ierror /= MPI_SUCCESS) call abort
+  end subroutine D_MPI_ALLREDUCE_INT32_IP_S
   subroutine D_MPI_ALLREDUCE_REAL32_IP(recvbuf, count, op, comm, ierror)
     implicit none
     real(real32), contiguous, intent(inout)   :: recvbuf(:)

--- a/src/modnamelist.f90
+++ b/src/modnamelist.f90
@@ -1,6 +1,7 @@
 !> Read namelists and check settings.
 module modnamelist
 
+  use modchecksim,     only: checksim_read_namelist
   use modmicrophysics, only: microphysics_read_namelist
 
   implicit none
@@ -15,6 +16,9 @@ contains
   subroutine read_namelists(nml_filename)
 
     character(len=*), intent(in) :: nml_filename
+
+    ! Core modules
+    call checksim_read_namelist(nml_filename)
 
     ! Add-on modules
     call microphysics_read_namelist(nml_filename)

--- a/src/modsampdata.f90
+++ b/src/modsampdata.f90
@@ -52,4 +52,19 @@ SAVE
   logical :: ltenddec = .false. !< switch to get variables needed to scale-decompose (processor-averaged) advective tendencies
   logical :: lqlflux = .false. !< switch to save ql flux
 
+  character(len=*), parameter :: tendnames(12) = [ &
+    'total/start         ', &
+    'horizontal advection', &
+    'vertical advection  ', &
+    'subgrid diffusion   ', &
+    'forces              ', &
+    'radiation           ', &
+    'large-scale forcing ', &
+    'microphysics        ', &
+    'top boundary        ', &
+    'Poisson solver      ', &
+    'addons              ', &
+    'Coriolis            '  &
+  ]
+
 end module modsampdata

--- a/src/modsamptend.f90
+++ b/src/modsamptend.f90
@@ -532,6 +532,7 @@ subroutine initsamptend
     use modfields, only : up,vp,wp,thlp,qtp,svp,w0,thl0,ql0,exnf,qt0,u0,v0,sv0
     use modmicrodata, only : iqr,inr
     use modstat_nc, only : lnetcdf
+    use modchecksim, only: lchecktend, checktend
     implicit none
     integer, intent(in)           :: tendterm !< name of the term to write down
     logical, intent(in), optional :: lastterm !< true if this is the last term of the equations; the write routine is entered.
@@ -540,6 +541,8 @@ subroutine initsamptend
     real, allocatable, dimension(:,:,:) :: thv0
     real, allocatable, dimension(:) :: thvav
     integer :: i,j,k
+
+    if (lchecktend) call checktend(tendnames(tendterm))
 
     if (.not. lsamptend) return
     if(isamptot < 1) return

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -34,6 +34,8 @@ use iso_c_binding
 use modprecision,      only : field_r
 use modtimer
 use modstat_nc
+use modchecksim, only: check_array
+use modstringutils, only: number2string
 
 implicit none
 ! private
@@ -419,6 +421,10 @@ contains
     call inittstep
 
     call checkinitvalues
+
+    ! TODO: invalid values here do stop the model. This is because the checksim 
+    ! namelist is not read yet at this point.
+    call check_initial_state
 
     call timer_toc('modstartup/startup')
 
@@ -1957,5 +1963,33 @@ contains
     call nchandle_error(nf90_close(ncid))
 
   end subroutine init_from_netcdf
+
+  !> Check prognostic variables before simulation
+  subroutine check_initial_state()
+    use modglobal, only: lmoist
+    use modfields, only: u0, v0, w0, thl0, qt0, sv0
+
+    ! Weird bug, casting thresholds to _field_r leads to compilation error for
+    ! some reason
+    integer, parameter :: rkind = kind(u0)
+
+    integer :: s
+
+    call check_array(u0, 'u0', 'startup', &
+                     threshold=[real(-100, rkind), real(100, rkind)])
+    call check_array(v0, 'v0', 'startup', &
+                     threshold=[real(-100, rkind), real(100, rkind)])
+    call check_array(w0, 'w0', 'startup', &
+                     threshold=[real(-30, rkind), real(30, rkind)])
+    call check_array(thl0, 'thl0', 'startup', &
+                     threshold=[real(150, rkind), real(350, rkind)])
+    if (lmoist) call check_array(qt0, 'qt0', 'startup', &
+                                 threshold=[real(0, rkind), real(1, rkind)])
+    
+    do s = 1, size(sv0, dim=4)
+      call check_array(sv0(:,:,:,s), 'sv0('//number2string(s)//')', 'startup')
+    end do
+    
+  end subroutine check_initial_state
 
 end module modstartup

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -426,8 +426,6 @@ contains
 
     call checkinitvalues
 
-    ! TODO: invalid values here do stop the model. This is because the checksim 
-    ! namelist is not read yet at this point.
     call check_initial_state
 
     call timer_toc('modstartup/startup')

--- a/src/modstringutils.f90
+++ b/src/modstringutils.f90
@@ -1,0 +1,72 @@
+module modstringutils
+
+  use, intrinsic :: iso_fortran_env, only: real32, real64
+
+  implicit none
+
+  private
+
+  interface number2string
+    module procedure :: int2string
+    module procedure :: real2string
+    module procedure :: double2string
+  end interface number2string
+
+  character(len=*), parameter :: modname = 'modstringutils'
+
+  public :: number2string
+
+contains
+
+  function int2string(n, opt_fmt) result(int_string)
+    integer,          intent(in) :: n
+    character(len=*), intent(in), optional :: opt_fmt
+
+    character(len=11) :: int_string
+    character(len=11) :: fmt
+
+    if (present(opt_fmt)) then
+      fmt = opt_fmt
+    else
+      fmt = '(i11)'
+    end if
+    write(int_string, fmt) n
+    int_string = adjustl(int_string)
+
+  end function int2string
+
+  function real2string(n, opt_fmt) result(real_string)
+    real(real32),     intent(in) :: n
+    character(len=*), intent(in), optional :: opt_fmt
+
+    character(len=32) :: real_string
+    character(len=11) :: fmt
+
+    if (present(opt_fmt)) then
+      fmt = opt_fmt
+    else
+      fmt = '(g32.5)'
+    end if
+    write(real_string, fmt) n
+    real_string = adjustl(real_string)
+
+  end function real2string
+
+  function double2string(n, opt_fmt) result(double_string)
+    real(real64),     intent(in) :: n
+    character(len=*), intent(in), optional :: opt_fmt
+
+    character(len=32) :: double_string
+    character(len=11) :: fmt
+
+    if (present(opt_fmt)) then
+      fmt = opt_fmt
+    else
+      fmt = '(g32.8)'
+    end if
+    write(double_string, fmt) n
+    double_string = adjustl(double_string)
+
+  end function double2string
+
+end module modstringutils


### PR DESCRIPTION
Based on 4e50030.

- Add option to check tendencies for invalid values, piggy-backing off of the `samptend` calls in the main program.
- Added a check of the main prognostic variables (u, v, w, thl, qt, sv) right after startup.
- Cleaned up `modchecksim`, separated reading of namelist (now called from `modnamelist`), replaced some arrays by in-place MPI calls.