### PR TITLE
Added time-dependent domain-averaged tendencies for scalars

### DIFF
--- a/src/modfields.f90
+++ b/src/modfields.f90
@@ -109,6 +109,8 @@ save
   real(field_r), allocatable :: dvdyls(:)                     !<   large scale y-gradient of v
   real(field_r), allocatable :: dvdtls(:)                     !<   large scale tendency of v
 
+  real(field_r), allocatable :: dsvdtls(:,:)                  !<   large scale tendency of tracers
+
   real(field_r), allocatable :: wfls  (:)                     !<   large scale vertical velocity
   real(field_r), allocatable :: ql0h(:,:,:)
   real(field_r), allocatable :: dthvdz(:,:,:)!<   theta_v at half level

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -259,7 +259,7 @@ contains
   use modfields, only : up,vp,thlp,qtp,svp,&
                         whls, u0av,v0av,thl0,qt0,sv0,u0,v0,&
                         dudxls,dudyls,dvdxls,dvdyls,dthldxls,dthldyls,dqtdxls,dqtdyls, &
-                        dqtdtls, dthldtls, dudtls, dvdtls,&
+                        dqtdtls, dthldtls, dudtls, dvdtls, dsvdtls, &
                         exnf,rhobf,ql0
   use modsprayingdata, only : lwater_spraying, lsalt_spraying,i_loc_spray,j_loc_spray,k_loc_spray,&
                               water_spray_rate,salt_spray_rate,&
@@ -327,10 +327,10 @@ contains
         do j = 1, j1
           do i = 1, i1
             if (whls(k+1).lt.0) then
-              svp(i,j,k,n) = svp(i,j,k,n) - whls(k+1) * (sv0(i,j,k+1,n) - sv0(i,j,k,n))/dzh(k+1)
+              svp(i,j,k,n) = svp(i,j,k,n) - whls(k+1) * (sv0(i,j,k+1,n) - sv0(i,j,k,n))/dzh(k+1) + dsvdtls(k,n)
             else
               if (k > 1) then
-                svp(i,j,k,n) = svp(i,j,k,n) - whls(k) * (sv0(i,j,k,n) - sv0(i,j,k-1,n))/dzh(k)
+                svp(i,j,k,n) = svp(i,j,k,n) - whls(k) * (sv0(i,j,k,n) - sv0(i,j,k-1,n))/dzh(k) + dsvdtls(k,n)
               end if
             end if
           end do

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -391,7 +391,7 @@ contains
     end if
 
     call readinitfiles ! moved to obtain the correct btime for the timedependent forcings in case of a warmstart
-    call inittimedep !depends on modglobal,modfields, modmpi, modsurf, modradiation
+    call inittimedep !depends on modglobal,modfields, modmpi, modsurf, modradiation, and on modtracers
     call initpois ! hypre solver needs grid and baseprofiles
     if(lopenbc) then  ! Correct boundaries and initial field for divergence
       ! Create 1/int(rho) - must be after rhobf has been initialized

--- a/src/modtimedepsv.f90
+++ b/src/modtimedepsv.f90
@@ -39,16 +39,16 @@ public :: inittimedepsv, timedepsv,ltimedepsv,exittimedepsv
 save
 ! switches for timedependent surface fluxes and large scale forcings
   logical       :: ltimedepsv     = .false. !< Overall switch, input in namoptions
-  logical       :: ltimedepsvz    = .false. !< Switch for large scale forcings
+  logical       :: ltimedepsvz    = .true.  !< Switch for large scale forcings
   logical       :: ltimedepsvsurf = .true.  !< Switch for surface fluxes
 
   integer :: kflux
   integer :: kls
   real, allocatable     :: timesvsurf (:)
-  real, allocatable     :: svst     (:,:) !< Time dependent surface scalar concentration
+  real, allocatable     :: wsvst     (:,:) !< Time dependent surface scalar flux
 
   real, allocatable     :: timesvz  (:)
-  real, allocatable     :: svzt(:,:,:) !< Time dependent, height dependent scalar concentrations
+  real, allocatable     :: dsvdtlst(:,:,:) !< Time dependent, height dependent large-scale scalar tendency
 
 
 
@@ -80,14 +80,14 @@ contains
 
     allocate(height(k1))
     allocate(timesvsurf (0:kflux))
-    allocate(svst  (kflux,nsv))
+    allocate(wsvst  (kflux,nsv))
     allocate(timesvz  (0:kls))
 
-    allocate(svzt(k1,kls,nsv))
+    allocate(dsvdtlst(k1,kls,nsv))
     timesvsurf = 0
-    timesvz   = 0
-    svst       = 0
-    svzt       = 0
+    timesvz    = 0
+    wsvst      = 0
+    dsvdtlst   = 0
 
     if (myid==0) then
 
@@ -110,8 +110,8 @@ contains
       ierr = 0
       do while (timesvsurf(t)< runtime)
         t=t+1
-        read(ifinput,*, iostat = ierr) timesvsurf(t), (svst(t,n),n=1,nsv)
-        write(*,'(f7.1,4e12.4)') timesvsurf(t), (svst(t,n),n=1,nsv)
+        read(ifinput,*, iostat = ierr) timesvsurf(t), (wsvst(t,n),n=1,nsv)
+        write(*,'(f7.1,4e12.4)') timesvsurf(t), (wsvst(t,n),n=1,nsv)
         if (ierr < 0) then
             stop 'STOP: No time dependend data for end of run (surface fluxes of scalar)'
         end if
@@ -141,10 +141,10 @@ contains
         end do
         write (*,*) 'timesvz = ',timesvz(t)
         do k=1,kmax
-          read (ifinput,*) height(k), (svzt(k,t,n),n=1,nsv)
+          read (ifinput,*) height(k), (dsvdtlst(k,t,n),n=1,nsv)
         end do
         do k=kmax,1,-1
-          write (6,outputfmt) height(k),(svzt(k,t,n),n=1,nsv)
+          write (6,outputfmt) height(k),(dsvdtlst(k,t,n),n=1,nsv)
         end do
       end do
 
@@ -159,12 +159,12 @@ contains
 
 
     call D_MPI_BCAST(timesvsurf(1:kflux),kflux,0,comm3d,mpierr)
-    call D_MPI_BCAST(svst             ,kflux*nsv,0,comm3d,mpierr)
+    call D_MPI_BCAST(wsvst             ,kflux*nsv,0,comm3d,mpierr)
     call D_MPI_BCAST(timesvz(1:kls)    ,kls,0,comm3d,mpierr)
     call D_MPI_BCAST(ltimedepsvsurf ,1,0,comm3d,mpierr)
     call D_MPI_BCAST(ltimedepsvz    ,1,0,comm3d,mpierr)
     do n=1,nsv
-         call D_MPI_BCAST(svzt(1:k1,1:kls,n),kmax*kls,0,comm3d,mpierr)
+         call D_MPI_BCAST(dsvdtlst(1:k1,1:kls,n),kmax*kls,0,comm3d,mpierr)
     enddo
     call timedepsv
 
@@ -183,17 +183,34 @@ contains
   end subroutine timedepsv
 
   subroutine timedepsvz
-  implicit none
+    use modfields, only : dsvdtls
+    use modglobal,   only : rtimee,nsv
+
+    use modmpi,      only : myid
+    implicit none
+
+    integer t,n
+    real fac
 
     if(.not.(ltimedepsvz)) return
-    stop 'Modtimedepsv: time dependent scalars at all levels not programmed'
+    
+    !---- interpolate ----
+    t=1
+    do while(rtimee>timesvz(t+1))
+       t=t+1
+    end do
+
+    fac = ( rtimee-timesvz(t) ) / ( timesvz(t+1)-timesvz(t) )
+    do n=1,nsv
+      dsvdtls(:,n)  = dsvdtlst (:,t,n) + fac * ( dsvdtlst (:,t+1,n) - dsvdtlst (:,t,n) )
+    end do
 
     return
   end subroutine timedepsvz
 
   subroutine timedepsvsurf
     use modglobal,   only : rtimee,nsv
-    use modsurfdata,  only : svs
+    use modsurfdata,  only : wsvsurf
     implicit none
     integer t,n
     real fac
@@ -211,7 +228,7 @@ contains
 
     fac = ( rtimee-timesvsurf(t) ) / ( timesvsurf(t+1)-timesvsurf(t))
     do n=1,nsv
-       svs(n) = svst(t,n) + fac * (svst(t+1,n) - svst(t,n))
+       wsvsurf(n) = wsvst(t,n) + fac * (wsvst(t+1,n) - wsvst(t,n))
     enddo
     return
   end subroutine timedepsvsurf
@@ -221,7 +238,7 @@ contains
     use modglobal, only : nsv
     implicit none
     if (nsv==0 .or. .not.ltimedepsv) return
-    deallocate(timesvz,svzt,timesvsurf)
+    deallocate(timesvz,dsvdtlst,timesvsurf)
   end subroutine exittimedepsv
 
 end module modtimedepsv

--- a/src/modtracers.f90
+++ b/src/modtracers.f90
@@ -28,7 +28,7 @@ module modtracers
   use modglobal,      only: nsv, i1, ih, j1, jh, k1, kmax, cexpnr, iinput, &
                             input_ascii
   use modprecision,   only: field_r
-  use modfields,      only: svm, sv0, svp, sv0av, svprof
+  use modfields,      only: svm, sv0, svp, sv0av, svprof, dsvdtls
   use modmpi,         only: myid, comm3d, d_mpi_bcast, print_info_stderr
   use go,             only: goSplitString_s
   use modstat_nc
@@ -224,19 +224,21 @@ contains
     allocate(svm(2-ih:i1+ih,2-jh:j1+jh,k1,nsv), &
              sv0(2-ih:i1+ih,2-jh:j1+jh,k1,nsv), &
              svp(2-ih:i1+ih,2-jh:j1+jh,k1,nsv), &
-             sv0av(k1,nsv), svprof(k1,nsv))
+             sv0av(k1,nsv), svprof(k1,nsv), &
+             dsvdtls(k1,nsv))
 
     svm(:,:,:,:) = 0
     sv0(:,:,:,:) = 0
     svp(:,:,:,:) = 0
     sv0av(:,:) = 0
     svprof(:,:) = 0
+    dsvdtls(:,:) = 0
 
     !$acc enter data copyin(svm(2-ih:i1+ih,2-jh:j1+jh,1:k1,1:nsv), &
     !$acc&                  sv0(2-ih:i1+ih,2-jh:j1+jh,1:k1,1:nsv), &
     !$acc&                  svp(2-ih:i1+ih,2-jh:j1+jh,1:k1,1:nsv), &
-    !$acc&                  sv0av(1:k1,1:nsv), svprof(1:k1,1:nsv))
-
+    !$acc&                  sv0av(1:k1,1:nsv), svprof(1:k1,1:nsv), &
+    !$acc&                  dsvdtls(1:k1,1:nsv))
   end subroutine allocate_tracers
 
   !> Deallocates all tracers fields
@@ -245,11 +247,12 @@ contains
     !$acc exit data delete(svm(2-ih:i1+ih,2-jh:j1+jh,1:k1,1:nsv), &
     !$acc&                 sv0(2-ih:i1+ih,2-jh:j1+jh,1:k1,1:nsv), &
     !$acc&                 svp(2-ih:i1+ih,2-jh:j1+jh,1:k1,1:nsv), &
-    !$acc&                 sv0av(1:k1,1:nsv), svprof(1:k1,1:nsv))
+    !$acc&                 sv0av(1:k1,1:nsv), svprof(1:k1,1:nsv), &
+    !$acc&                 dsvdtls(1:k1,1:nsv))
 
     if (nsv > 0) then
       deallocate(tracer_prop)
-      deallocate(svm, sv0, svp, sv0av, svprof)
+      deallocate(svm, sv0, svp, sv0av, svprof, dsvdtls)
     end if
 
   end subroutine exittracers


### PR DESCRIPTION
These can be prescribed in `ls_fluxsv.inp.001` as already possible for surface fluxes, doing something like this:

```
ls_flux_out = os.path.join(path_out, 'ls_fluxsv.inp.'+experiment)

# First write surface forcing
time = np.linspace(0,3600,100).reshape((100,1))
ws1surf = np.sin(2*np.pi*time/3600)
ws2surf = np.cos(2*np.pi*time/3600)

surf = np.stack((time_s,
                             ws1surf,
                             ws2surf,
                          )).T
f = open(ls_flux_out, 'w')
f.close()
np.savetxt(ls_flux_out, surf, fmt='%+10.9e', comments='',
           header='\n     time           ws1_s            ws2_s      \n      (s)          (kg kg-1 m s-1)           (kg kg-1 m s-1)      ')

# Append time instances which interpolate the vertical forcing
z = np.linspace(0,5000,100).reshape(1,100)
dsv1dtls = time*z # or something 
dsv2dtls = 10*time*z

with open(ls_flux_out, 'a') as f:
    f.write('\n       z (m)            dsv1dt (kg kg-1 s-1)            dsv2dt (kg kg-1 s-1)    \n')
    for i in range(len(time)):
        
        ls_profs = np.stack((z,
                                           dsv1dtls,
                                           dsv2dtls,
                           )).T
        f.write('\n# {:14.9e}\n'.format(time[i]))
        np.savetxt(f, ls_profs, fmt='%+10.10e')
```

I am running a few tests right now to see if this works as expected, but it seems fine so far. Also not sure if the GPU version needs things I haven't considered.