### PR TITLE
Move lookup tables for gamma function to `modbulkmicro`

### DIFF
--- a/src/bulkmicro_sb.f90
+++ b/src/bulkmicro_sb.f90
@@ -18,9 +18,10 @@
 !> Kernels for Seifert-Beheng microphysics
 module bulkmicro_sb
   use modglobal,         only: ih, jh, i1, j1, k1, nsv, rlv, cp, eps1, pi, rv, &
-                               mygamma21, mygamma251, pirhow, rhow
+                               pirhow, rhow
   use modmicrodata,      only: iqr, inr, Nc_0
-  use modbulkmicro_data, only: qrmin, qcmin, l_mur_cst, mur_cst, sig_gr
+  use modbulkmicro_data, only: qrmin, qcmin, l_mur_cst, mur_cst, sig_gr, &
+                               mygamma21, mygamma251
   use modprecision,      only: field_r
   use modtimer,          only: timer_tic, timer_toc
 

--- a/src/modbulkmicro.f90
+++ b/src/modbulkmicro.f90
@@ -52,7 +52,7 @@ module modbulkmicro
   use modmicrodata, only: Nc_0, sig_g, qtpmcr, thlpmcr, l_rain
   use modbulkmicro_data, only: qrbase, qrroof, qcbase, qcroof, qcmin, l_sb, &
                           l_sedc, l_mur_cst, l_lognormal, mur_cst, &
-                          sig_gr, c_St
+                          sig_gr, c_St, mygamma21, mygamma251
   use bulkmicro_sb, only: autoconversion_sb, &
                           accretion_sb, evaporation_sb, sedimentation_rain_sb
   use bulkmicro_kk, only: autoconversion_kk, &
@@ -79,6 +79,8 @@ module modbulkmicro
     use modtracers,   only: add_tracer
     implicit none
 
+    integer :: m
+
     ! Setup two tracers for precipitation
     call add_tracer("qr", long_name="rain water mixing ratio", &
                     unit="kg/kg", lmicro=.true., isv=iqr)
@@ -99,6 +101,25 @@ module modbulkmicro
     gamma25=gamma(2.5)
     gamma3=2.
     gamma35=gamma(3.5)
+
+    ! Setup lookup tables for ventilation factor in SB evaporation.
+    ! Entries are computed in double precision, and stored in field_r precision.
+    ! TODO: on GPU, it might be faster to inline the computation.
+    if (l_sb) then
+      mygamma21(-100) = 0.0
+      mygamma251(-100) = 0.0
+
+      do m = -99, 4000
+        mygamma21(m) = max(0.0_field_r, &
+          gamma(m/100.0 + 2.0) / gamma(m/100.0 + 1.0) &
+          * (((m/100.0 + 3.0)*(m/100.0 + 2.0)*(m/100.0 + 1.0))**(-1/3.0)))
+        mygamma251(m) = max(0.0, &
+          gamma(m/100.0 + 2.5) / gamma(m/100.0 + 1.0) &
+          * (((m/100.0 + 3.0)*(m/100.0 + 2.0)*(m/100.0 + 1.0))**(-1/2.0)))
+      end do
+
+      !$acc update device(mygamma21, mygamma251)
+    end if
 
     !$acc enter data copyin(Nr, qr, Nrp, qrp, precep, thlpmcr, qtpmcr)
 

--- a/src/modbulkmicro_data.f90
+++ b/src/modbulkmicro_data.f90
@@ -51,4 +51,11 @@ module modbulkmicro_data
     Nrp(:,:,:),             & !< Tendency of rain droplet number concentration.
     qrp(:,:,:)                !< Tendency of rain specific mixing ratio.
 
+  ! Gamma function lookup tables
+  real(field_r) :: &
+    mygamma21(-100:4000), &
+    mygamma251(-100:4000)
+
+  !$acc declare create(mygamma21, mygamma251)
+
 end module modbulkmicro_data

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -481,14 +481,12 @@ contains
 !     tnextrestart = trestart/tres
 !     timeleft=ceiling(runtime/tres)
 
-    !$acc enter data copyin(dzf, dzh, dzfi,dzhi, zh, zf, delta, deltai, &
-    !$acc&                  mygamma251, mygamma21)
+    !$acc enter data copyin(dzf, dzh, dzfi,dzhi, zh, zf, delta, deltai)
 
   end subroutine initglobal
 !> Clean up when leaving the run
   subroutine exitglobal
-    !$acc exit data delete(dzf, dzh, zh, zf, delta, deltai, &
-    !$acc&                 mygamma251, mygamma21)
+    !$acc exit data delete(dzf, dzh, zh, zf, delta, deltai)
 
     deallocate(dzf,dzh,dzfi,dzhi,zh,zf,delta,deltai)
   end subroutine exitglobal

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -143,10 +143,6 @@ save
 
       real :: lambda_crit=100. !< maximum value for the smoothness. This controls if WENO or
 
-      ! Tabulated saturation relation
-      real, dimension(-100:4000) :: mygamma251
-      real, dimension(-100:4000) :: mygamma21
-
       logical :: lmoist   = .true.  !<   switch to calculate moisture fields
       logical :: lnoclouds = .false. !<   switch to enable/disable thl calculations
       logical :: lfast_thermo = .true. !<   switch to enable faster icethermo scheme
@@ -332,13 +328,6 @@ contains
     end if
 
     ! Global constants
-
-    mygamma251(-100)=0.
-    mygamma21(-100)=0.
-    do m=-99,4000
-      mygamma251(m)=max(lacz_gamma(m/100._dp+2.5_dp)/lacz_gamma(m/100._dp+1._dp)*( ((m/100.+3)*(m/100.+2)*(m/100.+1))**(-1./2.) ),0.)
-      mygamma21(m)=max(lacz_gamma(m/100._dp+2._dp)/lacz_gamma(m/100._dp+1._dp)*( ((m/100.+3)*(m/100.+2)*(m/100.+1))**(-1./3.) ),0.)
-    end do
 
     ! Select advection scheme for scalars. If not set in the options file, the momentum scheme is used
     if (iadv_tke<0) iadv_tke = iadv_mom


### PR DESCRIPTION
These tables are only used by the Seifert-Beheng scheme, so I removed them from `modglobal`. Also switched to using the intrinsic gamma function in favor of the odd `lacz_gamma` for filling in the tables.