### PR TITLE
fix qr statistics

### DIFF
--- a/src/modcape.f90
+++ b/src/modcape.f90
@@ -120,13 +120,14 @@ contains
 
 !>Run crosssection.
   subroutine docape
-    use modglobal, only : imax,jmax,i1,j1,k1,kmax,nsv,rlv,cp,rv,rd,rk3step,timee,rtimee,dt_lim,grav,eps1,&
-    nsv,zf,dzf,tup,tdn,zh,kcb
+    use modglobal, only : imax,jmax,i1,j1,k1,kmax,rlv,cp,rv,rd,rk3step,timee,rtimee,dt_lim,grav,eps1,&
+    zf,dzf,tup,tdn,zh,kcb
     use modfields, only : u0,v0,thl0,qt0,ql0,w0,sv0,exnf,thvf,exnf,presf,rhobf
     use modstat_nc, only : lnetcdf, writestat_nc
     use modgenstat, only : qlmnlast,wthvtmnlast
-    use modmicrodata, only : iqr, precep, imicro
+    use modmicrodata, only : precep, imicro, imicro_bulk, imicro_sice, imicro_sice2
     use modthermodynamics, only: ttab, esatltab, esatitab
+    use modtracers, only: get_tracer_index
     use modmpi
 #if defined(_OPENACC)
     use modgpu, only: update_host
@@ -143,7 +144,7 @@ contains
     logical,allocatable :: capemask(:,:,:)
 
     ! LOCAL VARIABLES
-    integer :: i,j,k,ktest,tlonr,thinr,niter,nitert,kdmax,kdmaxl
+    integer :: i,j,k,ktest,tlonr,thinr,niter,nitert,kdmax,kdmaxl,iqr
     real :: Tnr,Tnr_old,ilratio,tlo,thi,esl1,esi1,qsatur,thlguess,thlguessmin,ttry,qvsl1,qvsi1
     real :: thv_sum, rho_sum, thv_avg, u_sum, v_sum, tmpk, tmpkp
 
@@ -247,8 +248,11 @@ contains
     enddo
     enddo
 
-    if(nsv>1) then
-    if(imicro>0) then
+    iqr = get_tracer_index("qr")
+    if (iqr == 0) then
+       iqr = get_tracer_index("qhr")
+    endif
+    if (iqr > 0) then
       do k=1,k1
       do j=2,j1
       do i=2,i1
@@ -256,12 +260,13 @@ contains
       enddo
       enddo
       enddo
+   endif
+   if (imicro == imicro_sice .or. imicro == imicro_sice2 .or. imicro == imicro_bulk) then
       do j=2,j1
       do i=2,i1
       sprec(i,j)=precep(i,j,1)*rhobf(1) ! correct for density to find total rain mass-flux
       enddo
       enddo
-    endif
     endif
 
     ! Cloud base level quantities and reset tops

--- a/src/modgenstat.f90
+++ b/src/modgenstat.f90
@@ -536,14 +536,16 @@ contains
                           ijtot,cu,cv,iadv_sv,iadv_kappa,eps1,dxi,dyi,tup,tdn,lopenbc
     use modmpi,    only : comm3d,mpi_sum,mpierr,slabsum,D_MPI_ALLREDUCE
     use advec_kappa, only : halflev_kappa
-    use modmicrodata, only: iqr
     use modsimpleice_data, only: tuprsg, tdnrsg
     use modthermodynamics, only: qsat_tab
+    use modtracers, only: get_tracer_index
+    use modmicrodata, only : imicro, imicro_sice, imicro_sice2
+
     implicit none
 
     real :: cthl,cqt,den
 
-    integer :: i, j, k, n
+    integer :: i, j, k, n, iqr
     real :: tsurf, c1, c2
     real :: qs0h, t0h, ekhalf, euhalf, evhalf
     real :: wthls, wthlr, wqts, wqtr, wqls, wqlr, wthvs, wthvr
@@ -656,7 +658,7 @@ contains
     if (nsv > 0) then
       !$acc host_data use_device(svmav, svm)
       do n = 1, nsv
-        call slabsum(svmav(1:1,n),1,k1,svm(:,:,:,n),2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1)
+        call slabsum(svmav(:,n),1,k1,svm(:,:,:,n),2-ih,i1+ih,2-jh,j1+jh,1,k1,2,i1,2,j1,1,k1)
       enddo
       !$acc end host_data
     end if
@@ -704,6 +706,7 @@ contains
     cthl = (exnh(1)*cp/rlv)*((1-den)/den)
     cqt = 1./den
 
+    iqr = get_tracer_index("qr")
     !$acc parallel loop collapse(2) default(present) private(upcu, vpcv) &
     !$acc& reduction(+: qlhav(1), wthlsub(1), wqtsub(1), wthvsub(1), uwsub(1), vwsub(1), hurav(1), clwav(1), cliav(1), plwav(1), pliav(1)) async(1)
     do j = 2, j1
@@ -734,9 +737,13 @@ contains
         cliav(1) = cliav(1) + ql0(i,j,1) * (1-ilratio)
 
         if (iqr > 0) then
-           ilratio = max(0._field_r,min(1._field_r,(tmp0(i,j,1)-tdnrsg)/(tuprsg-tdnrsg)))
-           plwav(1) = plwav(1) + sv0(i,j,1,iqr) * ilratio
-           pliav(1) = pliav(1) + sv0(i,j,1,iqr) * (1-ilratio)
+           if (imicro == imicro_sice .or. imicro == imicro_sice2) then
+              ilratio = max(0._field_r,min(1._field_r,(tmp0(i,j,1)-tdnrsg)/(tuprsg-tdnrsg)))
+              plwav(1) = plwav(1) + sv0(i,j,1,iqr) * ilratio
+              pliav(1) = pliav(1) + sv0(i,j,1,iqr) * (1-ilratio)
+           else
+              plwav(1) = plwav(1) + sv0(i,j,1,iqr)
+           end if
         end if
       end do
     end do
@@ -840,9 +847,13 @@ contains
           cliav_s = cliav_s + ql0(i,j,k) * (1-ilratio)
 
           if (iqr > 0) then
-            ilratio = max(0._field_r,min(1._field_r,(tmp0(i,j,k)-tdnrsg)/(tuprsg-tdnrsg)))
-            plwav_s = plwav_s + sv0(i,j,k,iqr) * ilratio
-            pliav_s = pliav_s + sv0(i,j,k,iqr) * (1-ilratio)
+             if (imicro == imicro_sice .or. imicro == imicro_sice2) then
+                ilratio = max(0._field_r,min(1._field_r,(tmp0(i,j,k)-tdnrsg)/(tuprsg-tdnrsg)))
+                plwav_s = plwav_s + sv0(i,j,k,iqr) * ilratio
+                pliav_s = pliav_s + sv0(i,j,k,iqr) * (1-ilratio)
+             else
+                plwav_s = plwav_s + sv0(i,j,k,iqr)
+             end if
           end if
 
           if (ql0h(i,j,k)>0) then

--- a/src/modtimestat.f90
+++ b/src/modtimestat.f90
@@ -406,7 +406,7 @@ contains
 
     use modglobal,  only : i1,j1, k1,kmax,zf,dzf,cu,cv,rv,rd,eps1, &
                           ijtot,timee,rtimee,dt_lim,rk3step,cexpnr,ifoutput
-    use modmicrodata, only : imicro, iqr, imicro_sice, imicro_sice2, imicro_bulk, precep
+    use modmicrodata, only : imicro, imicro_sice, imicro_sice2, imicro_bulk, imicro_bulk3, precep
     use modfields,  only : e120,qt0,ql0,u0av,v0av,rhobf,rhof,u0,v0,w0,sv0
     use modsurfdata,only : wtsurf, wqsurf, isurf,ustar,thlflux,qtflux,z0,oblav,qts,thls,&
                            Qnet, H, LE, G0, rs, ra, tskin, tendskin, &
@@ -421,6 +421,7 @@ contains
 #endif
     use modraddata, only :  lwd,lwu,swd,swu,lwdca,lwuca,swdca,swuca, &
                             iradiation, doclearsky
+    use modtracers, only : get_tracer_index
     implicit none
 
     real(field_r)   :: zbaseavl, ztopavl, ztopmaxl, ztop, zbaseminl
@@ -476,7 +477,7 @@ contains
       s_swu_tom_ca,  & !< TOM upwelling shortwave flux, clear sky
       s_lwu_tom_ca     !< TOM upwelling longwave flux, clear sky
 
-    integer:: i, j, k, ilu
+    integer:: i, j, k, ilu, iqr
 
     if (.not.(ltimestat)) return
     if (rk3step/=3) return
@@ -613,8 +614,12 @@ contains
       end do
     end if
 
-    if (imicro == imicro_sice .or. imicro == imicro_sice2 .or. imicro == imicro_bulk) then
-      !$acc parallel loop collapse(2) default(present) reduction(+:qrintavl) &
+    if (imicro == imicro_sice .or. imicro == imicro_sice2 .or. imicro == imicro_bulk .or. imicro == imicro_bulk3) then
+       iqr = get_tracer_index("qr")
+       if (iqr == 0) then
+          iqr = get_tracer_index("qhr")
+       endif
+       !$acc parallel loop collapse(2) default(present) reduction(+:qrintavl) &
       !$acc& private(qrint) async
       do j = 2, j1
         do i = 2, i1


### PR DESCRIPTION
When saving rain statistics in profiles, tmser and cape, get iqr from the tracer manager, and don't use nsv to detect if qr is present or not.