### PR TITLE
preventing division by 0 in modbulkmicro3_point.f90

### DIFF
--- a/src/modbulkmicro3_point.f90
+++ b/src/modbulkmicro3_point.f90
@@ -2968,7 +2968,7 @@ subroutine sb_evmelt3(avent0,avent1,bvent0,bvent1,x_bmin,n_e,n_ep,n_em &
   g_me= - k_melt*(ktdtodv*(tmp0-T_3)+dvleorv*(esl/tmp0-eslt3/T_3))
 
   ! calculating real mean particle mass
-  x_er = q_e/n_e
+  x_er  = q_e/(n_e+eps0)
 
   ! calculating N_re Reynolds number
   nrex= D_e*v_e/nu_a


### PR DESCRIPTION
Fixing the possible division by 0 in subroutine `sb_evmelt3` in  modbulkmicro3_point.f90, since the calling subroutine (`evapmelting3`) checks only for mass concentration but not for number concentration. Crash reported by @YPChu0723   in test case rf20_composite_setup