### PR TITLE
modtimestat: use explicit loops instead of sum()

### DIFF
--- a/src/modtimestat.f90
+++ b/src/modtimestat.f90
@@ -758,23 +758,36 @@ contains
 !     -------------------------
 !     9.6  Horizontally  Averaged ustar, tstar and obl
 !     -------------------------
-    !$acc kernels default(present) async
-    ustl=sum(ustar(2:i1,2:j1))
-    tstl=sum(- thlflux(2:i1,2:j1) / ustar(2:i1,2:j1))
-    qstl=sum(- qtflux (2:i1,2:j1) / ustar(2:i1,2:j1))
-    !$acc end kernels
+
+    ustl = 0
+    tstl = 0
+    qstl = 0
+    !$acc parallel loop collapse(2) default(present) reduction(+:ustl,tstl,qstl) async
+    do j = 2, j1
+       do i = 2, i1
+          ustl = ustl + ustar(i,j)
+          tstl = tstl - thlflux(i,j) / ustar(i,j)
+          qstl = qstl - qtflux (i,j) / ustar(i,j)
+       end do
+    end do
 
     if(isurf < 3) then
-      !$acc kernels default(present) async
-      thlfluxl = sum(thlflux(2:i1, 2:j1))
-      qtfluxl  = sum(qtflux (2:i1, 2:j1))
-      !$acc end kernels
+       thlfluxl = 0
+       qtfluxl  = 0
+       !$acc parallel loop collapse(2) default(present) reduction(+:thlfluxl,qtfluxl) async
+       do j = 2, j1
+          do i = 2, i1
+             thlfluxl = thlfluxl + thlflux(i, j)
+             qtfluxl  = qtfluxl  + qtflux (i, j)
+          end do
+       end do
     end if
+    ! note ! ACC wait is far below
 
   ! -----------------------------------
   ! 9.7 Communication and normalisation
   ! -----------------------------------
-    !$acc wait
+
     call D_MPI_ALLREDUCE(ccl   , cc   , 1,       &
                           MPI_SUM, comm3d,mpierr)
     call D_MPI_ALLREDUCE(qlintavl, qlintav, 1  , &
@@ -790,7 +803,14 @@ contains
     call D_MPI_ALLREDUCE(zbaseminl, zbasemin, 1, &
                           MPI_MIN, comm3d,mpierr)
     if (imicro == imicro_sice .or. imicro == imicro_sice2 .or. imicro == imicro_bulk) then
-       pravl = sum(precep(2:i1,2:j1,1))
+       pravl = 0
+       !$acc parallel loop collapse(2) default(present) reduction(+:pravl)
+       do j = 2, j1
+          do i = 2, i1
+             pravl = pravl + precep(i,j,1)
+          end do
+       end do
+
        call D_MPI_ALLREDUCE(pravl, prav, 1, MPI_SUM, comm3d,mpierr)
     end if
     if (lhetero) then
@@ -852,6 +872,7 @@ contains
 
     tke_tot = tke_tot / ijtot
 
+    !$acc wait ! wait for sum of ustl etc and thlfluxl,qtfluxl
     call D_MPI_ALLREDUCE(ustl, ust, 1, MPI_SUM, comm3d,mpierr)
     call D_MPI_ALLREDUCE(tstl, tst, 1, MPI_SUM, comm3d,mpierr)
     call D_MPI_ALLREDUCE(qstl, qst, 1, MPI_SUM, comm3d,mpierr)


### PR DESCRIPTION
I could not get the sum() inside !$acc kernels to work on GPU.