### PR TITLE
Fixes for uninitialized memory and switch to own RRTMG_LW

### DIFF
--- a/src/microphysics.inc
+++ b/src/microphysics.inc
@@ -31,7 +31,7 @@ function calc_xr(rho, qr, nr, xrmin, xrmax) result(xr)
   real(field_r) :: xr
   !$acc routine seq
 
-  xr = rho * qr / nr
+  xr = rho * qr / (nr + 1e-6)
   xr = min(max(xr, xrmin), xrmax)
 
 end function calc_xr

--- a/src/modbulkmicro.f90
+++ b/src/modbulkmicro.f90
@@ -98,6 +98,7 @@ module modbulkmicro
     allocate(thlpmcr  (2:i1,2:j1,k1)  & !
             ,qtpmcr(2-ih:i1+ih,2-jh:j1+jh,k1))  ! ghost cells added here for modvarbudget
 
+    precep = 0
     gamma25=gamma(2.5)
     gamma3=2.
     gamma35=gamma(3.5)

--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -288,7 +288,7 @@ contains
 
     character(len=*), intent(in) :: step
 
-    call check_array(qtp, "qtp", step, [-0.01_field_r, -0.01_field_r])
+    call check_array(qtp, "qtp", step, [-0.01_field_r, 0.01_field_r])
     call check_array(thlp, "thlp", step, [-20.0_field_r, 20.0_field_r])
   
   end subroutine checktend

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -149,6 +149,7 @@ save
       logical :: lfast_thermo = .true. !<   switch to enable faster icethermo scheme
       logical :: lsgbucorr= .false.  !<   switch to enable subgrid buoyancy flux
       logical :: lconstexner = .false.  !<  switch to use the initial pressure profile in the exner function
+      logical :: lbaseexner = .false.   !<  switch to use the base pressure profile in the exner function
 
       ! Poisson solver: modpois / modhypre
       ! set default solver, can be overridden in namoptions

--- a/src/modlsm.f90
+++ b/src/modlsm.f90
@@ -72,12 +72,11 @@ subroutine lsm
     call calc_hydraulic_properties
     ! Calculate tendency due to root water extraction
     call calc_root_water_extraction
-    ! Solve diffusion equation:
-    call integrate_theta_soil
 
     ! Update liquid water reservoir
     call calc_liquid_reservoir
-
+    ! Solve diffusion equation:
+    call integrate_theta_soil
 end subroutine lsm
 
 !

--- a/src/modlsm.f90
+++ b/src/modlsm.f90
@@ -1266,6 +1266,7 @@ subroutine integrate_theta_soil
     use modglobal, only : rk3step, rdt, i1, j1, rhow, rlv
     use modsurfdata, only : phiw, phiwm, lambdash, gammash
     use modmpi, only : myidx, myidy
+    use modchecksim, only : check_array
     implicit none
     integer :: i, j, k
     real :: tend, rk3coef, flux_top, fac
@@ -1316,13 +1317,7 @@ subroutine integrate_theta_soil
     end do
 
     ! Range check of phiw
-    if (maxval(phiw) > 1 .or. minval(phiw) < 0) then
-       write(*,*) 'phiw out or range 0...1'
-       write(*,*) 'myid{x,y} =', myidx, myidy
-       write(*,*) 'max', maxval(phiw), 'at', maxloc(phiw)
-       write(*,*) 'min', minval(phiw), 'at', minloc(phiw)
-       !stop
-    end if
+    call check_array(phiw, "phiw", "integrate_theta_soil", [0.0, 1.0])
 
 end subroutine integrate_theta_soil
 
@@ -1595,6 +1590,9 @@ subroutine allocate_fields
 
     ilu_ws = nlu
 
+    ! initialize, especially the un-used halo
+    phiw = 0
+    phiwm = 0
 end subroutine allocate_fields
 
 !

--- a/src/modlsm.f90
+++ b/src/modlsm.f90
@@ -740,7 +740,7 @@ subroutine calc_obuk_ustar_ra(tile)
 
     do j=2,j1
         do i=2,i1
-            if (tile%frac(i,j) > 0) then
+            !if (tile%frac(i,j) > 0) then
                 ! Buoyancy difference surface - atmosphere
                 thvs = tile%thlskin(i,j) * (1.+(rv/rd-1.)*tile%qtskin(i,j))
                 tile%db(i,j) = grav/thvs * (thv_1(i,j) - thvs)
@@ -752,17 +752,17 @@ subroutine calc_obuk_ustar_ra(tile)
                 ! Iteratively find Obukhov length
                 tile%obuk(i,j) = calc_obuk_dirichlet( &
                     tile%obuk(i,j), du_tot(i,j), tile%db(i,j), real(zf(1), 8), tile%z0m(i,j), tile%z0h(i,j))
-            end if
+            !end if
         end do
     end do
 
     do j=2,j1
         do i=2,i1
-            if (tile%frac(i,j) > 0) then
+            !if (tile%frac(i,j) > 0) then
                 ! Calculate friction velocity and aerodynamic resistance
                 tile%ustar(i,j) = du_tot(i,j) * fm(real(zf(1), 8), tile%z0m(i,j), tile%obuk(i,j))
                 tile%ra(i,j)    = 1./(tile%ustar(i,j) * fh(real(zf(1), 8), tile%z0h(i,j), tile%obuk(i,j)))
-            end if
+            !end if
         end do
     end do
 
@@ -790,7 +790,9 @@ subroutine calc_tile_bcs(tile)
 
     do j=2, j1
         do i=2, i1
-            if (tile%frac(i,j) > 0) then
+           ! if (tile%frac(i,j) > 0) then
+           ! perhaps not necessary to calculate if frac is 0,
+           ! this way all tiles are up to date
 
                 ! Disable canopy resistance in case of dew fall
                 Ts    = tile%thlskin(i,j) * exnh(1)
@@ -844,7 +846,7 @@ subroutine calc_tile_bcs(tile)
                 ! Calculate surface values
                 tile%thlskin(i,j) = thl0(i,j,1) + tile%wthl(i,j) * tile%ra(i,j)
                 tile%qtskin (i,j) = qt0 (i,j,1) + tile%wqt (i,j) * tile%ra(i,j)
-            end if
+!            end if
         end do
     end do
 
@@ -866,7 +868,7 @@ subroutine calc_water_bcs(tile)
 
     do j=2, j1
       do i=2, i1
-        if (tile%frac(i,j) > 0) then
+        !if (tile%frac(i,j) > 0) then
             !! Calculate BCs. `tile_aq%tskin` is fixed in time (for now...)
             !tile_aq%thlskin(i,j) = tile_aq%tskin(i,j) / exnh(1)
             !esats = 0.611e3 * exp(17.2694 * (tile_aq%tskin(i,j) - 273.16) / (tile_aq%tskin(i,j) - 35.86))
@@ -894,7 +896,7 @@ subroutine calc_water_bcs(tile)
             tile%H (i,j) = tile%wthl(i,j) * rhof(1) * cp
             tile%LE(i,j) = tile%wqt (i,j) * rhof(1) * rlv
             tile%G (i,j) = 0.
-        end if
+        !end if
       end do
     end do
 
@@ -971,17 +973,6 @@ subroutine calc_bulk_bcs
             dudz(i,j) = ustar(i,j) / (fkar * zf(1)) * phim(zf(1)/obl(i,j)) * (ucu/du_tot(i,j))
             dvdz(i,j) = ustar(i,j) / (fkar * zf(1)) * phim(zf(1)/obl(i,j)) * (vcv/du_tot(i,j))
 
-            ! Cyclic BCs where needed.
-            ustar_3D(1:i2,1:j2,1:1) => ustar
-
-            if(lopenbc) then ! Only use periodicity for non-domain boundaries when openboundaries are used
-              call openboundary_excjs(ustar_3D, 2,i1,2,j1,1,1,1,1, &
-                   & (.not.lboundary(1:4)).or.lperiodic(1:4))
-           else
-              !call excjs(ustar,2,i1,2,j1,1,1,1,1)
-              call excjs(ustar_3D,2,i1,2,j1,1,1,1,1)
-           endif
-
             ! Just for diagnostics (modlsmcrosssection)
             do ilu=1,nlu
               !if (trim(tile(ilu)%lushort) == 'ws') then
@@ -1019,6 +1010,16 @@ subroutine calc_bulk_bcs
             end do
         end do
     end do
+
+    ! Cyclic BCs where needed.
+    ustar_3D(1:i2,1:j2,1:1) => ustar
+    if(lopenbc) then ! Only use periodicity for non-domain boundaries when openboundaries are used
+       call openboundary_excjs(ustar_3D, 2,i1,2,j1,1,1,1,1, &
+            & (.not.lboundary(1:4)).or.lperiodic(1:4))
+    else
+       !call excjs(ustar,2,i1,2,j1,1,1,1,1)
+       call excjs(ustar_3D,2,i1,2,j1,1,1,1,1)
+    endif
 
 end subroutine calc_bulk_bcs
 
@@ -1966,7 +1967,7 @@ subroutine init_heterogeneous_nc
     use modmpi,      only : myid, myidx, myidy
     use modglobal,   only : imax, jmax, itot, jtot, ldrydep
 
-    use modsurfdata, only : tsoil, phiw, wl, wlm, wmax
+    use modsurfdata, only : tsoil, tskin, phiw, wl, wlm, wmax
     implicit none
 
     !integer       :: ilu_lv, ilu_hv, ilu_aq, ilu_ap, ilu_ws, ilu_bs
@@ -2070,7 +2071,7 @@ subroutine init_heterogeneous_nc
     tile(nlu)%H = 0
     tile(nlu)%LE = 0
     tile(nlu)%G = 0
-
+    tile(nlu)%ustar = 0
 
     ! 2D surface fields
     do ilu=1,nlu-1
@@ -2089,6 +2090,7 @@ subroutine init_heterogeneous_nc
       tile(ilu)%H = 0
       tile(ilu)%LE = 0
       tile(ilu)%G = 0
+      tile(ilu)%ustar = 0
 
       write(*,*) 'reading variables for LU type: ', trim(tile(ilu)%lushort)
       ! LU cover
@@ -2258,8 +2260,8 @@ subroutine init_heterogeneous_nc
     tile(ilu_ws)%base_frac(:,:) = 0.
 
     ! Set properties wet skin tile
-    tile(ilu_ws)%z0m(:,:) = 0
-    tile(ilu_ws)%z0h(:,:) = 0
+    tile(ilu_ws)%z0m(:,:) = 1e-4
+    tile(ilu_ws)%z0h(:,:) = 1e-4
     tile(ilu_ws)%lambda_stable(:,:) = 0
     tile(ilu_ws)%lambda_unstable(:,:) = 0
 
@@ -2307,6 +2309,12 @@ subroutine init_heterogeneous_nc
     enddo
     wl_max(:,:) = wl_max(:,:) * wmax/land_frac(:,:)
     where (wl_max == 0) wl_max = eps1
+
+    ! initialize tskin
+    tskin(:,:) = 0
+    do ilu=1,nlu
+       tskin(:,:) = tskin(:,:) + tile(ilu)%base_frac(:,:) * tile(ilu)%tskin(:,:)
+    end do
 
     ! initialize frac to base_frac (for now the dynamic wet skin is not done unless ldrydep is true)
     do ilu=1,nlu

--- a/src/modscalarpulse.f90
+++ b/src/modscalarpulse.f90
@@ -30,8 +30,12 @@ save
 ! pulse governing variables (from namelist)
   logical :: lscalarpulse     = .false.
   logical :: lcpmip           = .false.
-  integer(kind=longint) :: timepulse
-  real    :: amppulse, kpulse, zminpulse, zmaxpulse, radius
+  integer(kind=longint) :: timepulse = 3600
+  real    :: amppulse  = 0
+  real    :: kpulse    = 1
+  real    :: zminpulse = 0
+  real    :: zmaxpulse = 200
+  real    :: radius    = 1000
   real(field_r), allocatable :: qtav0(:),qtav1(:)
 
 contains

--- a/src/modsimpleice2.f90
+++ b/src/modsimpleice2.f90
@@ -108,6 +108,9 @@ module modsimpleice2
     !$acc&                  lambdag, precep, &
     !$acc&                  ccrz, ccsz, ccgz, ccrz2, ccsz2, ccgz2)
 
+    !$acc kernels default(present)
+    precep=0
+    !$acc end kernels
   end subroutine initsimpleice2
 
 !> Cleaning up after the run

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -583,7 +583,6 @@ contains
 
     real(field_r), allocatable :: height(:), th0av(:)
     real(field_r), allocatable :: thv0(:,:,:)
-    integer, allocatable :: scalar_indices(:)
 
     character(len=512) :: chmess
     integer, parameter :: maxcol = 50
@@ -595,7 +594,6 @@ contains
     allocate (height(k1))
     allocate (th0av(k1))
     allocate (thv0(2-ih:i1+ih,2-jh:j1+jh,k1))
-    allocate (scalar_indices(nsv))
 
     if (.not. lwarmstart) then
 
@@ -747,7 +745,6 @@ contains
 
       call D_MPI_BCAST(wsvsurf,        nsv,    0, comm3d, mpierr)
       call D_MPI_BCAST(svprof,         k1*nsv, 0, comm3d, mpierr)
-      call D_MPI_BCAST(scalar_indices, nsv,    0, comm3d, mpierr)
 
       ! Initialize fields
       if(lopenbc .and. linithetero) then! Openboundaries with heterogeneous initialisation

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1997,7 +1997,7 @@ contains
     call check_array(w0, 'w0', 'startup', &
                      threshold=[real(-30, rkind), real(30, rkind)])
     call check_array(thl0, 'thl0', 'startup', &
-                     threshold=[real(150, rkind), real(350, rkind)])
+                     threshold=[real(150, rkind), real(2000, rkind)])
     if (lmoist) call check_array(qt0, 'qt0', 'startup', &
                                  threshold=[real(0, rkind), real(1, rkind)])
     

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -73,13 +73,14 @@ contains
                                   lwarmstart,startfile,trestart,&
                                   nsv,itot,jtot,kmax,xsize,ysize,xlat,xlon,xyear,xday,xtime,&
                                   lmoist,lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,cu,cv,&
-                                  ifnamopt,fname_options,llsadv,lconstexner,&
+                                  ifnamopt,fname_options,llsadv,lconstexner,lbaseexner, &
                                   ibas_prf,lambda_crit,iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv,courant,peclet,ladaptive,author,&
                                   lnoclouds,lfast_thermo,lrigidlid,unudge,ntimedep,&
                                   solver_id, maxiter, maxiter_precond, tolerance, n_pre, n_post, precond_id, checknamelisterror, &
                                   loutdirs, output_prefix, &
-                                  lopenbc,linithetero,lperiodic,dxint,dyint,dzint,dxturb,dyturb,taum,tauh,pbc,lsynturb,nmodes,tau,lambda,lambdas,lambdas_x,lambdas_y,lambdas_z,iturb, &
-                                  hypre_logging,rdt,rk3step,i1,j1,k1,ih,jh,lboundary,lconstexner, iinput,dzf
+                                  lopenbc,linithetero,lperiodic,dxint,dyint,dzint,dxturb,dyturb,taum,tauh,pbc,&
+                                  lsynturb,nmodes,tau,lambda,lambdas,lambdas_x,lambdas_y,lambdas_z,iturb, &
+                                  hypre_logging,rdt,rk3step,i1,j1,k1,ih,jh,lboundary,iinput,dzf
     use modforces,         only : lforce_user
     use modsurfdata,       only : z0,ustin,wtsurf,wqsurf,wsvsurf,ps,thls,isurf
     use modsurface,        only : initsurface
@@ -139,7 +140,7 @@ contains
         z0,ustin,wtsurf,wqsurf,ps,thls,lmoist,isurf,chi_half,&
         lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,ltimedep,ltimedepuv,ltimedepsv,ntimedep,&
         irad,timerad,iradiation,rad_ls,rad_longw,rad_shortw,rad_smoke,useMcICA,&
-        rka,dlwtop,dlwbot,sw0,gc,reff,isvsmoke,lforce_user,lcloudshading,lrigidlid,unudge,lfast_thermo,lconstexner
+        rka,dlwtop,dlwbot,sw0,gc,reff,isvsmoke,lforce_user,lcloudshading,lrigidlid,unudge,lfast_thermo,lconstexner,lbaseexner
     namelist/DYNAMICS/ &
         llsadv,  lqlnr, lambda_crit, cu, cv, ibas_prf, iadv_mom, iadv_tke, iadv_thl, iadv_qt, iadv_sv, lnoclouds
     namelist/SOLVER/ &
@@ -271,7 +272,7 @@ contains
     call D_MPI_BCAST(unudge      ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(lfast_thermo,1,0,commwrld,mpierr)
     call D_MPI_BCAST(lconstexner ,1,0,commwrld,mpierr)
-
+    call D_MPI_BCAST(lbaseexner  ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(irad       ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(timerad    ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(iradiation ,1,0,commwrld,mpierr)
@@ -547,7 +548,7 @@ contains
                                   rtimee,timee,ntrun,btime,dt_lim,nsv,&
                                   zf,dzf,dzh,rv,rd,cp,rlv,pref0,om23_gs,&
                                   ijtot,cu,cv,e12min,dzh,cexpnr,ifinput,lwarmstart,ltotruntime,itrestart,&
-                                  trestart, ladaptive,llsadv,tnextrestart,longint,lconstexner,lopenbc, linithetero, &
+                                  trestart, ladaptive,llsadv,tnextrestart,longint,lconstexner,lbaseexner,lopenbc,linithetero, &
                                   iinput, input_netcdf, input_ascii, lcoriol
     use modsubgrid,        only : ekm,ekh
     use modsurfdata,       only : wsvsurf, &
@@ -966,12 +967,14 @@ contains
       host_is_updated = .false.
 #endif
 
-      if (lconstexner) then
-        exnf(:) = (initial_presf(:)/pref0)**(rd/cp)
-        exnh(:) = (initial_presh(:)/pref0)**(rd/cp)
-      else
-        exnf(:) = (presf(:)/pref0)**(rd/cp)
-        exnh(:) = (presh(:)/pref0)**(rd/cp)
+      if (.not. lbaseexner) then
+         if (lconstexner) then
+            exnf(:) = (initial_presf(:)/pref0)**(rd/cp)
+            exnh(:) = (initial_presh(:)/pref0)**(rd/cp)
+         else
+            exnf(:) = (presf(:)/pref0)**(rd/cp)
+            exnh(:) = (presh(:)/pref0)**(rd/cp)
+         endif
       endif
 
       do k = 2, k1
@@ -1664,7 +1667,7 @@ contains
     ! Calculates the profiles corresponding to the base state
     ! In the current implementation, neither the base pressure, nor the base virtual temperature plays a role in the dynamics
     ! They are nevertheless calculated and printed to the stdin/baseprof files for user convenience
-    use modfields,         only : rhobf,rhobh,drhobdzf,drhobdzh
+    use modfields,         only : rhobf,rhobh,drhobdzf,drhobdzh,exnf,exnh
     use modglobal,         only : k1,kmax,zf,zh,dzf,dzh,rv,rd,grav,cp,pref0,lwarmstart,ibas_prf,cexpnr,ifinput,ifoutput
     use modsurfdata,       only : thls,ps,qts
     use modmpi,            only : myid,comm3d,mpierr,D_MPI_BCAST
@@ -1672,16 +1675,16 @@ contains
 
     real :: thvb,prsb ! for calculating moist adiabat
     integer :: j,k
-    real, allocatable :: height(:),pb(:),tb(:)
+    real(field_r), allocatable :: height(:),pb(:),tb(:),pbh(:)
     character(80) chmess
     real :: zsurf=0.
     real :: tsurf
-    real,dimension(4) :: zmat=(/11000.,20000.,32000.,47000./)
-    real,dimension(4) :: lapserate=(/-6.5/1000.,0.,1./1000,2.8/1000/)
-    real,dimension(4) :: pmat
-    real,dimension(4) :: tmat
+    real(field_r),dimension(4) :: zmat=(/11000.,20000.,32000.,47000./)
+    real(field_r),dimension(4) :: lapserate=(/-6.5/1000.,0.,1./1000,2.8/1000/)
+    real(field_r),dimension(4) :: pmat
+    real(field_r),dimension(4) :: tmat
 
-    allocate (height(k1),pb(k1),tb(k1))
+    allocate (height(k1),pb(k1),tb(k1),pbh(k1))
 
     if(myid==0)then
 
@@ -1840,9 +1843,11 @@ contains
 
       do k = 2, k1
         rhobh(k) = (rhobf(k)*dzf(k-1)+rhobf(k-1)*dzf(k))/(dzf(k)+dzf(k-1))
+        pbh(k)   = (   pb(k)*dzf(k-1)+   pb(k-1)*dzf(k))/(dzf(k)+dzf(k-1)) ! interpolate base half-level pressure like half-level base rho 
       end do
 
       rhobh(1) = rhobf(1)-(rhobf(2)-rhobf(1))*(zf(1)-zh(1))/(zf(2)-zf(1))
+      pbh(1)   = ps
 
       ! calculate derivatives
       do k = 1, kmax
@@ -1873,6 +1878,11 @@ contains
                 drhobdzh (k)
       end do
 
+    ! exner function from base profiles
+    ! these are overwritten in modthermodynamics unless lbaseexner is true
+    exnf = (pb/pref0)**(rd/cp)
+    exnh = (pbh/pref0)**(rd/cp)
+
     end if ! ENDIF MYID=0
 
     ! MPI broadcast variables
@@ -1880,8 +1890,10 @@ contains
     call D_MPI_BCAST(rhobh       ,k1,0,comm3d,mpierr)
     call D_MPI_BCAST(drhobdzf    ,k1,0,comm3d,mpierr)
     call D_MPI_BCAST(drhobdzh    ,k1,0,comm3d,mpierr)
+    call D_MPI_BCAST(exnf        ,k1,0,comm3d,mpierr)
+    call D_MPI_BCAST(exnh        ,k1,0,comm3d,mpierr)
 
-    deallocate(height,pb,tb)
+    deallocate(height,pb,tb,pbh)
 
   end subroutine baseprofs
 

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -358,7 +358,7 @@ contains
 !!     qt,ql,exner,pressure and the density
 !! \author      Pier Siebesma   K.N.M.I.     06/01/1995
   subroutine diagfld
-  use modglobal,  only : i1,ih,j1,jh,k1,nsv,zh,zf,cu,cv,ijtot,grav,rlv,cp,rd,rv,pref0,timee,lconstexner
+  use modglobal,  only : i1,ih,j1,jh,k1,nsv,zh,zf,cu,cv,ijtot,grav,rlv,cp,rd,rv,pref0,timee,lconstexner,lbaseexner
   use modfields,  only : u0,v0,thl0,qt0,ql0,sv0,u0av,v0av,thl0av,qt0av,ql0av,sv0av, &
                         presf,presh,exnf,exnh,rhof,thvf
   use modsurfdata,only : thls,ps
@@ -421,7 +421,7 @@ contains
     sv0av  = sv0av /ijtot
     !$acc end kernels
   end if
-  if (timee < 0.01 .or. .not. lconstexner) then
+  if ((timee < 0.01 .or. .not. lconstexner) .and. .not. lbaseexner) then
     !$acc kernels default(present)
     exnf   = 1-grav*zf/(cp*thls)
     exnh   = 1-grav*zh/(cp*thls)
@@ -442,7 +442,7 @@ contains
 
    !$acc kernels default(present)
    th0av = thl0av + (rlv/cp)*ql0av/exnf
-   if (timee < 0.01 .or. .not. lconstexner) then
+   if ((timee < 0.01 .or. .not. lconstexner) .and. .not. lbaseexner) then
       exnf = (presf/pref0)**(rd/cp)
    endif
    !$acc end kernels
@@ -457,7 +457,7 @@ contains
 !***********************************************************
 
 !  3.1 determine exner
-   if (timee < 0.01 .or. .not. lconstexner) then
+   if ((timee < 0.01 .or. .not. lconstexner) .and. .not. lbaseexner) then
      !$acc serial default(present) async(1)
      exnh(1) = (ps/pref0)**(rd/cp)
      exnf(1) = (presf(1)/pref0)**(rd/cp)


### PR DESCRIPTION
Various fixes for uninitialized memory

* switch to own fork of RRTMG_LW  until this issue is resolved https://github.com/AER-RC/RRTMG_LW/issues/19
   - fixes nan results from radiation with debug build, and out-of-bounds access in foggy conditions
* fix uninitialized parameters for modscalarpulse - no harm done if the module is not active, but trips the debug build
* modlsm: run the surface scheme for all tiles even when their fraction is 0
* modlsm: move ustar MPI exchange out of 2D loop
