### PR TITLE
update gfortran debug build flags

### DIFF
--- a/cmake/dales_compile_options.cmake
+++ b/cmake/dales_compile_options.cmake
@@ -2,7 +2,7 @@
 if( CMAKE_Fortran_COMPILER_ID MATCHES GNU )
   ecbuild_add_fortran_flags( "-cpp -W -Wall -Wno-tabs -Wno-compare-reals -fdefault-real-8 -fdefault-double-8 -march=native -ffree-line-length-none -std=gnu -Werror=implicit-interface" )
   ecbuild_add_fortran_flags( "-funroll-all-loops -fno-f2c -Ofast -g -fbacktrace" BUILD RELEASE )
-  ecbuild_add_fortran_flags( "-finit-real=nan -fbounds-check -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" BUILD DEBUG )
+  ecbuild_add_fortran_flags( "-finit-real=snan -fcheck=all -fbacktrace -fno-f2c -O0 -g -ffpe-trap=invalid,zero,overflow" BUILD DEBUG )
 elseif( CMAKE_Fortran_COMPILER_ID MATCHES Intel )
   ecbuild_add_fortran_flags( "-cpp -r8 -ftz" )
   ecbuild_add_fortran_flags( "-O3" BUILD RELEASE )


### PR DESCRIPTION
...inspired by CaNS.

* initialize reals to signalling NaNs - perhaps catch use of them earlier
* check "all" instead of just bounds. Additional checks enabled include warning when temporary arrays are generated, and checks of pointers and memory.