### PR TITLE
Fix missing timer toc and check every timer is properly formed

### DIFF
--- a/src/modbulkmicro.f90
+++ b/src/modbulkmicro.f90
@@ -444,7 +444,10 @@ module modbulkmicro
 
     call timer_tic(routine, 1)
 
-    if (qcbase > qcroof) return
+    if (qcbase > qcroof) then
+       call timer_toc(routine)
+       return
+    endif
 
     csed = c_St*(3./(4.*pi*rhow))**(2./3.)*exp(5.*log(sig_g)**2.)
 

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -143,7 +143,10 @@ contains
     call D_MPI_BCAST(z0h_wall           ,    1, 0, comm3d, mpierr)
 
     !< Step out of further subroutine when IBM is switched off
-    if (.not. (lapply_ibm)) return
+    if (.not. (lapply_ibm)) then
+       call timer_toc('modibm/initibm')
+       return
+    endif
 
     ! TODO change to allow for wall dependent roughness
     ! Calculate law-of-wall coefficients for vertical walls (constant; no stability correction on vertical walls)

--- a/src/modtimer.f90
+++ b/src/modtimer.f90
@@ -323,7 +323,7 @@ contains
         print*,'WARNING: malformed timer: ', timer_names(i)
       end if
     end do
-    if (.not.allocated(timer_names)) then
+    if (allocated(timer_names)) then
       deallocate(timer_names,timer_counts,timer_counter,timer_elapsed_acc,timer_elapsed_min,timer_elapsed_max)
     end if
   end subroutine timer_cleanup

--- a/src/modtimer.f90
+++ b/src/modtimer.f90
@@ -23,6 +23,7 @@ module modtimer
   integer, parameter :: max_name_len = 50
   character(max_name_len), allocatable :: timer_names(:)
   integer , allocatable :: timer_counts(:)
+  integer , allocatable :: timer_counter(:)
   real(dp), allocatable :: timer_tictoc(:),timer_elapsed_acc(:), &
                                            timer_elapsed_min(:), &
                                            timer_elapsed_max(:)
@@ -192,10 +193,11 @@ contains
     !@cuf integer :: istat
 
     if (.not. ltimer) return
-    
+
     if(.not.allocated(timer_names)) then
       allocate(timer_names(      0), &
                timer_counts(     0), &
+               timer_counter(    0), &
                timer_tictoc(     0), &
                timer_elapsed_acc(0), &
                timer_elapsed_min(0), &
@@ -208,6 +210,7 @@ contains
       ntimers = ntimers + 1
       call concatenate_c(timer_names,timer_name)
       timer_counts      = [timer_counts     ,0          ]
+      timer_counter     = [timer_counter    ,0          ]
       timer_tictoc      = [timer_tictoc     ,0._dp      ]
       timer_elapsed_acc = [timer_elapsed_acc,0._dp      ]
       timer_elapsed_min = [timer_elapsed_min,huge(0._dp)]
@@ -215,6 +218,7 @@ contains
       timer_is_nvtx     = [timer_is_nvtx    ,.false.    ]
       idx = ntimers
     end if
+    timer_counter(idx)     = timer_counter(idx) + 1
     timer_tictoc(idx) = MPI_WTIME()
 #if defined(USE_NVTX)
     is_nvtx = .false.
@@ -281,6 +285,7 @@ contains
       timer_elapsed_min(idx) = min(timer_elapsed_min(idx),timer_tictoc(idx))
       timer_elapsed_max(idx) = max(timer_elapsed_max(idx),timer_tictoc(idx))
       timer_counts(idx)      = timer_counts(idx) + 1
+      timer_counter(idx)     = timer_counter(idx) - 1
       if(timer_is_nvtx(idx)) then
         is_gpu_sync = GPU_DEFAULT_SYNC
         if(present(nvtx_gpu_stream)) then
@@ -312,8 +317,14 @@ contains
     end if
   end subroutine timer_toc
   subroutine timer_cleanup
+    integer :: i
+    do i = 1,ntimers
+      if (timer_counter(i) .ne. 0) then
+        print*,'WARNING: malformed timer: ', timer_names(i)
+      end if
+    end do
     if (.not.allocated(timer_names)) then
-      deallocate(timer_names,timer_counts,timer_elapsed_acc,timer_elapsed_min,timer_elapsed_max)
+      deallocate(timer_names,timer_counts,timer_counter,timer_elapsed_acc,timer_elapsed_min,timer_elapsed_max)
     end if
   end subroutine timer_cleanup
   integer function timer_search(timer_name)

--- a/src/program.f90
+++ b/src/program.f90
@@ -170,7 +170,7 @@ program DALES
 !     0.2     USE STATEMENTS FOR TIMER MODULE
 !----------------------------------------------------------------
 
-  use modtimer,       only : timer_tic, timer_toc, timer_print, timer_write
+  use modtimer,       only : timer_tic, timer_toc, timer_print, timer_write, timer_cleanup
 
 !----------------------------------------------------------------
 !     0.3     USE STATEMENTS FOR GPU UTILITIES
@@ -400,6 +400,7 @@ program DALES
 !-------------------------------------------------------
 
   call timer_print
+  call timer_cleanup
   call timer_write
 
 !--------------------------------------------------------


### PR DESCRIPTION
Check number of tic is equal to the number of toc. Doesn't handle a case where a toc would be called before a tic.