### PR TITLE
Fixed uninitialized iqr bugs, moved some initialization routines

### DIFF
--- a/src/daleslib.f90
+++ b/src/daleslib.f90
@@ -157,15 +157,12 @@ module daleslib
             call inittimestat  ! Timestat must preceed all other timeseries that could write in the same netCDF file (unless stated otherwise
             call initgenstat   ! Genstat must preceed all other statistics that could write in the same netCDF file (unless stated otherwise
             !call inittilt
-            call initsampling
             call initquadrant
             call initcrosssection
             call initAGScross
             call initlsmcrosssection
             !call initprojection
             call initcloudfield
-            call initfielddump
-            call initsamptend
             call initradstat
             call initradfield
             call initlsmstat
@@ -177,12 +174,15 @@ module daleslib
             call initvarbudget
             !call initstressbudget
             call initchem
+            call initsampling
+            call initfielddump
+            call initsamptend
             call initheterostats
             call initcanopy
-
+            
             !call initspectra2
             call initcape
-
+            
             !Set additional library information
             my_task=myid
             master_task=0

--- a/src/modfielddump.f90
+++ b/src/modfielddump.f90
@@ -76,10 +76,10 @@ contains
     use modglobal,only :imax,jmax,kmax,cexpnr,ifnamopt,fname_options,dtmax,dtav_glob,kmax, ladaptive,dt_lim,btime,tres,&
          checknamelisterror, output_prefix
     use modstat_nc,only : lnetcdf,open_nc, define_nc,ncinfo,nctiminfo,writestat_dims_nc
-    use modtracers, only : tracer_prop
+    use modtracers, only : tracer_prop, get_tracer_index
     use modmicrodata, only : imicro, imicro_sice, imicro_sice2
     implicit none
-    integer :: ierr, n
+    integer :: ierr, n, iqr
     character(3) :: csvname
 
     namelist/NAMFIELDDUMP/ &
@@ -103,6 +103,14 @@ contains
          lcli = .false.
          lclw = .false.
       end if
+      if (lplw.or.lpli) then
+        iqr = get_tracer_index("qr")
+      endif
+      if ((iqr == 0).and.((lplw.or.lpli))) then
+        print *, "lplw or lpli are true but there is no qr tracer. Turning plw and pli output off."
+        lplw = .false.
+        lpli = .false. 
+      endif
     end if
     call D_MPI_BCAST(ncoarse     ,1,0,comm3d,ierr)
     call D_MPI_BCAST(klow        ,1,0,comm3d,ierr)
@@ -272,10 +280,10 @@ contains
                           timee,dt_lim,cexpnr,ifoutput,rtimee,cp,tdn,tup
     use modmpi,    only : myid,cmyidx, cmyidy
     use modstat_nc, only : lnetcdf, writestat_nc
-    use modmicrodata, only : iqr, imicro, imicro_none
     use modsimpleice_data, only: tuprsg, tdnrsg
     use modraddata, only   :lwu,lwd,swu,swd
     use modthermodynamics, only: qsat_tab
+    use modtracers, only : get_tracer_index
 #if defined(_OPENACC)
     use modgpu, only: update_host
 #endif
@@ -283,7 +291,7 @@ contains
 
     integer(KIND=selected_int_kind(4)), allocatable :: field(:,:,:)
     real, allocatable :: vars(:,:,:,:)
-    integer i,j,k,n,ii,jj
+    integer i,j,k,n,ii,jj,iqr
     integer :: writecounter = 1
     integer :: reclength
 
@@ -301,6 +309,9 @@ contains
 
     ! Only write fields if time is in the range (tmin, tmax)
     if (timee < itmin .or. timee > itmax) return
+
+    iqr = get_tracer_index("qr")
+
 
     !$acc update self(u0) if(lu) async
     !$acc update self(v0) if(lv) async
@@ -399,7 +410,8 @@ contains
     end if
 
     if (lbinary) then
-      if(imicro/=imicro_none) then
+      ! iqr was set via get_tracer_index, if iqr>0 qr exists and we can do calculations independent of microphysics scheme.
+      if(iqr>0) then
          do i=2-ih,i1+ih
             do j=2-jh,j1+jh
                do k=1,k1
@@ -458,6 +470,7 @@ contains
     ! liquid and ice precip
     ! assuming simpleice is used
     !rsgratio_= max(0._field_r,min(1._field_r,(tmp0(i,j,k)-tdnrsg)/(tuprsg-tdnrsg))) ! rain vs snow/graupel partitioning   rsg = 1 if t > tuprsg
+    ! we're assuming iqr is nonzero as in initfielddump we checked qr presence and disabled lplw and lpli if qr was not present
     if (lnetcdf .and. lplw) vars(:,:,:,ind_plw) = sv0(2:i1:ncoarse,2:j1:ncoarse,klow:khigh,iqr) * &
          max(0._field_r,min(1._field_r,(tmp0(2:i1:ncoarse,2:j1:ncoarse,klow:khigh)-tdnrsg)/(tuprsg-tdnrsg)))
     if (lnetcdf .and. lpli) vars(:,:,:,ind_pli) = sv0(2:i1:ncoarse,2:j1:ncoarse,klow:khigh,iqr)  * &

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -66,10 +66,10 @@ contains
   use modglobal, only : kmax,dzh,dzf,grav, lpressgrad, lcoriol
   use modfields, only : sv0,up,vp,wp,thv0h,dpdxl,dpdyl,thvh
   use moduser,   only : force_user
-  use modmicrodata, only : imicro, imicro_bulk, imicro_bin, imicro_sice, imicro_sice2, iqr
+  use modtracers, only : get_tracer_index
   implicit none
 
-  integer k
+  integer k,iqr
 
   call timer_tic('modforces/forces', 0)
 
@@ -85,7 +85,9 @@ contains
     !$acc end kernels
   end if
 
-  if((imicro==imicro_sice).or.(imicro==imicro_sice2).or.(imicro==imicro_bulk).or.(imicro==imicro_bin)) then
+  ! we check if tracer qr exists, otherwise we don't use it. Should be functionally identical to checking microphysics schem.
+  iqr = get_tracer_index("qr")
+  if(iqr>0) then
     !$acc kernels default(present) async(2)
     do k=2,kmax
        wp(:,:,k) = wp(:,:,k) + grav*(thv0h(:,:,k)-thvh(k))/thvh(k) - &

--- a/src/modradfull.f90
+++ b/src/modradfull.f90
@@ -116,13 +116,17 @@ contains
     use modglobal,    only : i1,ih,j1,jh,kmax,k1,cp,dzf,dzh,rlv,rd,pref0
     use modfields,    only : rhof, exnf,exnh, thl0,qt0,ql0,sv0
     use modsurfdata,  only : albedo, ps
-    use modmicrodata, only : imicro, imicro_bulk, Nc_0,iqr
+    use modmicrodata, only : imicro, imicro_bulk, Nc_0
     use modraddata,   only : thlprad, lwd,lwu,swd,swu
+    use modtracers,   only : get_tracer_index
       implicit none
     real :: thlpld,thlplu,thlpsd,thlpsu
-    integer :: i,j,k
+    integer :: i,j,k,iqr
 
     real :: exnersurf
+
+    ! we get the qr tracer index instead of using iqr from modmicrodata as that is initialized to -1.
+    iqr = get_tracer_index("iqr")
 
     allocate(rhof_b(k1),exnf_b(k1))
     allocate(temp_b(2-ih:i1+ih,2-jh:j1+jh,k1),qv_b(2-ih:i1+ih,2-jh:j1+jh,k1),ql_b(2-ih:i1+ih,2-jh:j1+jh,k1),rr_b(2-ih:i1+ih,2-jh:j1+jh,k1))
@@ -137,7 +141,8 @@ contains
             qv_b(i,j,k+1)   = max(0._field_r,qt0(i,j,k) - ql0(i,j,k))
             ql_b(i,j,k+1)   = ql0(i,j,k)
             temp_b(i,j,k+1) = thl0(i,j,k)*exnf(k)+(rlv/cp)*ql0(i,j,k)
-            if (imicro==imicro_bulk) rr_b(i,j,k+1) = sv0(i,j,k,iqr)
+            ! make sure we're using the right microphysics scheme AND that iqr is set, as get_tracer_index might return zero if iqr is unset.
+            if ((imicro==imicro_bulk).and.(iqr/=0)) rr_b(i,j,k+1) = sv0(i,j,k,iqr)
           end do
         end do
       end do

--- a/src/modsampling.f90
+++ b/src/modsampling.f90
@@ -65,10 +65,11 @@ contains
     use modglobal, only : ladaptive, dtmax,k1,ifnamopt,fname_options,kmax,   &
                           btime,tres,cexpnr,ifoutput,lwarmstart,checknamelisterror
     use modstat_nc, only : lnetcdf,define_nc,ncinfo,open_nc,define_nc,ncinfo,nctiminfo,writestat_dims_nc
+    use modtracers, only : get_tracer_index
 !     use modgenstat, only : idtav_prof=>idtav, itimeav_prof=>itimeav
     implicit none
 
-    integer :: ierr
+    integer :: ierr,iqr,inr
 
     namelist/NAMSAMPLING/ &
     dtav,timeav,lsampcl,lsampco,lsampup,lsampbuup,lsampcldup,lsamptend,lprocblock,ltenddec,ltendleib, &
@@ -82,7 +83,25 @@ contains
       call checknamelisterror(ierr, ifnamopt, 'NAMSAMPLING')
       write(6 ,NAMSAMPLING)
       close(ifnamopt)
+
+      ! we check the presence of qr and Nr here, so we can safely disable the modsamptend.f90 parts that require a nonzero iqr if
+      ! qr or Nr are not set.
+      if (lsamptendqr) then
+        iqr = get_tracer_index("qr")
+        if (iqr == 0) then
+          write(*,*) "lsamptendqr is true but tracer qr not found, disabling lsamptendqr"
+          lsamptendqr = .false.
+        endif
+      endif
+      if (lsamptendnr) then
+        inr = get_tracer_index("Nr")
+        if (inr == 0) then
+          write(*,*) "lsamptendnr is true but tracer qr not found, disabling lsamptendnr"
+          lsamptendnr = .false.
+        endif
+      endif
     end if
+
 
 
     call D_MPI_BCAST(timeav    ,1,0,comm3d,mpierr)
@@ -360,13 +379,14 @@ contains
   subroutine dosampling
     use modglobal, only : i1,i2,j1,j2,kmax,k1,ih,jh,&
                           dx,dy,dzh,dzf,cp,rv,rlv,rd,ijtot, &
-                          grav,om22,cu,nsv,zh
+                          grav,om22,cu,zh
     use modfields, only : u0,v0,w0,thl0,thl0h,qt0,qt0h,ql0,ql0h,thv0h,exnf,exnh,rhobf,rhobh,thvh, &
                           sv0,wp
     use modsubgriddata,only : ekh,ekm
     use modmpi,    only : slabsum,comm3d,mpierr,mpi_sum,D_MPI_ALLREDUCE
     use modpois,   only : p
-    use modmicrodata, only : imicro, imicro_bulk, imicro_bin, imicro_sice,iqr
+    use modmicrodata, only : imicro, imicro_bulk, imicro_bin, imicro_sice
+    use modtracers,  only : get_tracer_index
     implicit none
 
     logical, allocatable, dimension(:,:,:) :: maskf
@@ -383,7 +403,7 @@ contains
     real, allocatable, dimension(:) :: whav0 ,wwthav0  ,wwshav0 ,sigh0
     integer, allocatable, dimension (:) :: nrsamph0l, nrsamph0
 
-    integer :: i,j,k,km,kp
+    integer :: i,j,k,km,kp,iqr
     real :: cqt,cthl,den,ekhalf,c2,c1,t0h,qs0h,ekav
     real :: wthvsh,wthvrh,wthlsh,wthlrh,wqtrh,wqtsh,wqlrh,wqls
 
@@ -635,6 +655,10 @@ contains
     end do
 
 
+    ! we get the qr tracer index instead of using iqr from modmicrodata as that is initialized to -1.
+    iqr = get_tracer_index("qr")
+
+
 !add fields and fluxes to mean
 !     1)       fields on full levels
     do k=1,kmax
@@ -648,7 +672,8 @@ contains
       pfavl   (k,isamp) = pfavl   (k,isamp)+sum  (p    (2:i1,2:j1,k),maskf(2:i1,2:j1,k))
       wwsfavl (k,isamp) = wwsfavl (k,isamp)+sum  (wwsf (2:i1,2:j1,k),maskf(2:i1,2:j1,k))
     end do
-    if(nsv>1) then
+    ! we check if the tracer index for qr exists, otherwise we just add zero.
+    if(iqr>0) then
       do k=1,kmax
       do j=2,j1
       do i=2,i2
@@ -684,7 +709,9 @@ contains
       nrsamph0l  (k)       = count(maskh(2:i1,2:j1,k))
       whav0l     (k)       = sum(w0   (2:i1,2:j1,k),maskh(2:i1,2:j1,k))
 
-      if((imicro==imicro_sice).or.(imicro==imicro_bulk).or.(imicro==imicro_bin)) then
+      ! if iqr == 0 it means something has gone wrong in initializing, this probably then needs to be caught earlier, but this
+      ! check prevents a segfault
+      if(((imicro==imicro_sice).or.(imicro==imicro_bulk).or.(imicro==imicro_bin)).and.(iqr>0)) then
         do j=2,j1
         do i=2,i1
          if (maskh(i,j,k)) then

--- a/src/modsamptend.f90
+++ b/src/modsamptend.f90
@@ -530,9 +530,9 @@ subroutine initsamptend
                           cp,rv,rlv,rd,&
                           timee,rk3step,dt_lim,ijtot,nsv,rdt
     use modfields, only : up,vp,wp,thlp,qtp,svp,w0,thl0,ql0,exnf,qt0,u0,v0,sv0
-    use modmicrodata, only : iqr,inr
     use modstat_nc, only : lnetcdf
     use modchecksim, only: lchecktend, checktend
+    use modtracers, only : get_tracer_index
     implicit none
     integer, intent(in)           :: tendterm !< name of the term to write down
     logical, intent(in), optional :: lastterm !< true if this is the last term of the equations; the write routine is entered.
@@ -540,7 +540,7 @@ subroutine initsamptend
     real, allocatable, dimension(:,:,:) :: w0f
     real, allocatable, dimension(:,:,:) :: thv0
     real, allocatable, dimension(:) :: thvav
-    integer :: i,j,k
+    integer :: i,j,k,iqr,inr
 
     if (lchecktend) call checktend(tendnames(tendterm))
 
@@ -552,6 +552,13 @@ subroutine initsamptend
       dt_lim = minval((/dt_lim,tnext-timee,tnextwrite-timee/))
       return
     end if
+    ! in initsampling we have already checked if iqr,inr!=0, so we can safely assume that they are nonzero here
+    if (lsamptendqr) then
+      iqr = get_tracer_index("qr")
+    endif
+    if (lsamptendnr) then
+      inr = get_tracer_index("Nr")
+    endif
 
     IF (present(firstterm)) THEN
     IF (firstterm) THEN
@@ -833,17 +840,24 @@ subroutine initsamptend
     ! Terms/variables needed to scale-decompose the advection terms, for each selected budget
     use modglobal, only : i1,imax,j1,jmax,k1,dzhi,dzf,dzh
     use modfields, only : w0,thl0,thl0h,qt0,qt0h,u0,v0,sv0, ql0, ql0h
-    use modmicrodata, only : iqr,inr
     use modsubgriddata, only : ekh
     use modsurfdata,only: thlflux,qtflux,svflux
+    use modtracers, only : get_tracer_index
     implicit none
     real :: ekhalf, thlhav, qthav, qrhav, qr0h, nrhav, nr0h, qlhav
     real :: thlwavr, thlsavr, qtwavr, qtsavr
     real :: qrwavr, qrsavr, nrwavr, nrsavr, qlwavr, qlsavr
     real :: wthlavr, wqtavr, wqravr, wnravr, wqlavr
-    integer :: i,j,k
+    integer :: i,j,k,inr,iqr
 
     if(.not.(ltenddec)) return
+      ! in initsampling we have already checked if iqr,inr!=0, so we can safely assume that they are nonzero here
+      if (lsamptendqr) then
+        iqr = get_tracer_index("qr")
+      endif
+      if (lsamptendnr) then
+        inr = get_tracer_index("nr")
+      endif
 
       uwavr = 0.
       vsavr = 0.
@@ -1082,16 +1096,25 @@ subroutine initsamptend
                           cp,rv,rlv,rd,&
                           ijtot
     use modfields, only : w0,thl0,ql0,exnf,qt0,u0,v0,sv0
-    use modmicrodata, only : iqr,inr
+    use modtracers, only : get_tracer_index
     implicit none
     real, allocatable, dimension(:,:,:) :: w0f
     real, allocatable, dimension(:,:,:) :: thv0
     real, allocatable, dimension(:) :: thvav
-    integer :: i,j,k
+    integer :: i,j,k,iqr,inr
 
 
     if (.not. lsamptend) return
     if(.not.(ldosamptendleib)) return
+
+    ! in initsampling we have already checked if iqr,inr!=0, so we can safely assume that they are nonzero here
+    if (lsamptendqr) then
+      iqr = get_tracer_index("qr")
+    endif
+    if (lsamptendnr) then
+      inr = get_tracer_index("nr")
+    endif
+
     ldosamptendleib=.false.
     tendmask=.false.
     nrsampnew=0

--- a/src/program.f90
+++ b/src/program.f90
@@ -201,7 +201,6 @@ program DALES
   call inittimestat  ! Timestat must preceed all other timeseries that could write in the same netCDF file (unless stated otherwise
   call initgenstat   ! Genstat must preceed all other statistics that could write in the same netCDF file (unless stated otherwise
   !call inittilt
-  call initsampling
   call initquadrant
   call initcrosssection
   call initAGScross
@@ -209,8 +208,6 @@ program DALES
   call initdepcrosssection
   !call initprojection
   call initcloudfield
-  call initfielddump
-  call initsamptend
   call initradstat
   call initradfield
   call initlsmstat
@@ -223,10 +220,12 @@ program DALES
   call initvarbudget
   call initmsebudg
   !call initstressbudget
-! call initchem
+  ! call initchem
+  call initsampling
+  call initfielddump
+  call initsamptend
   call initheterostats
   call initcanopy
-
   !call initspectra2
   call initscalarpulse
   call initcape


### PR DESCRIPTION
Some subroutines still used iqr/inr from modmicrodata without either:

- adding tracer qr/Nr and therefore initializing iqr themselves
- knowing if qr/Nr existed.
This PR replaces this behavior with get_tracer_index, with some checks if iqr!=0, so that we know for sure we can use it.
This also moves the samptend,sampling,fielddump initialization routines after the microphysics initialization routine, so we check if qr/nr was added, and disable certain output routines that require them if qr/nr was not added.