### PR TITLE
modstat_nc: add optional zstandard support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,9 @@ if( ENABLE_RRTMG )
   add_compile_definitions( USE_RRTMG )
 endif()
 
-if( ENABLE_ZSTANDARD )
-  add_compile_definitions( NC_ZSTANDARD )
-endif()
+# Zstandard compression
+include( dales_check_zstandard )
+dales_check_zstandard()
 
 # GPU stuff
 
@@ -137,4 +137,5 @@ if( ENABLE_ACC OR ENABLE_NVTX )
 endif()
 
 include( dales_compile_options )
+
 add_subdirectory( src )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ if( ENABLE_RRTMG )
   add_compile_definitions( USE_RRTMG )
 endif()
 
+if( ENABLE_ZSTANDARD )
+  add_compile_definitions( NC_ZSTANDARD )
+endif()
+
 # GPU stuff
 
 include( dales_find_cuda )

--- a/cmake/dales_check_zstandard.cmake
+++ b/cmake/dales_check_zstandard.cmake
@@ -1,0 +1,42 @@
+# Check the NetCDF library for Zstandard compression support.
+macro( dales_check_zstandard )
+
+  ecbuild_info( "Testing NetCDF for Zstandard support" )
+
+  set( TMPDIR "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp" )
+
+  file( WRITE "${TMPDIR}/test_zstd.f90"
+        "
+        program test_zstd
+        use netcdf
+        implicit none
+        integer :: ncid, dimid, varid, istat
+        istat = nf90_create('${TMPDIR}/test.nc', NF90_CLOBBER, ncid)
+        istat = nf90_def_dim(ncid, 'x', 1, dimid)
+        istat = nf90_def_var(ncid, 'y', NF90_INT, [dimid], varid)
+        istat = nf90_def_var_zstandard(ncid, varid, 4)
+        stop istat
+        end program
+        "
+  )
+
+  ecbuild_try_run( EXITCODE COMPILED
+                   ${TMPDIR} "${TMPDIR}/test_zstd.f90"
+                   CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${NetCDF_Fortran_INCLUDE_DIR}"
+                   LINK_LIBRARIES ${NetCDF_Fortran_LIBRARY}
+  )
+
+  if( ${COMPILED} )
+    if( ${EXITCODE} EQUAL 0 )
+      ecbuild_info( "Testing NetCDF for Zstandard support - Success" )
+      add_compile_definitions( NC_ZSTANDARD )
+    else()
+      ecbuild_info( "Testing NetCDF for Zstandard support - Failed" )
+      ecbuild_info( "   - test_zstd.f90 did not run succesfully. NetCDF-C is likely not compiled with Zstandard support." )
+    endif()
+  else()
+    ecbuild_info( "Testing NetCDF for Zstandard support - Failed" )
+    ecbuild_info( "   - test_zstd.f90 did not compile succesfully. You are likely using an old version of NetCDF-Fortran." )
+  endif()
+
+endmacro()

--- a/src/modstat_nc.f90
+++ b/src/modstat_nc.f90
@@ -36,6 +36,7 @@ module modstat_nc
     logical :: lsync   = .false.     ! Sync NetCDF file after each writestat_*_nc
     logical :: lclassic = .false.    ! Create netCDF in CLASSIC format (less RAM usage, compression not supported)
     integer :: deflate = 2           ! Deflate level for netCDF files (only for NETCDF4 format)
+    integer :: zstandard = 0         ! Zstandard level for netCDF files (only for NETCDF4 format).
 
     integer, save :: timeID=0, ztID=0, zmID=0, xtID=0, xmID=0, ytID=0, ymID=0,ztsID=0, zqID=0
     real(kind=4) :: nc_fillvalue = -999.
@@ -78,7 +79,7 @@ contains
     integer             :: ierr
 
     namelist/NAMNETCDFSTATS/ &
-    lnetcdf, lsync, lclassic, deflate
+    lnetcdf, lsync, lclassic, deflate, zstandard
 
     if(myid==0)then
       open(ifnamopt,file=fname_options,status='old',iostat=ierr)
@@ -92,6 +93,7 @@ contains
     call D_MPI_BCAST(lsync      ,1, 0,comm3d,mpierr)
     call D_MPI_BCAST(lclassic   ,1, 0,comm3d,mpierr)
     call D_MPI_BCAST(deflate    ,1, 0,comm3d,mpierr)
+    call D_MPI_BCAST(zstandard  ,1, 0,comm3d,mpierr)
 
   end subroutine initstat_nc
 !
@@ -331,10 +333,18 @@ contains
         call nchandle_error(iret)
       end if
 
-      if (deflate > 0 .and. .not. lclassic) then
-         call nchandle_error(nf90_def_var_deflate(ncid,varID, 0, 1, deflate_level = deflate))
-         ! NETCDF4 only
+      if (.not. lclassic) then ! NETCDF4 only
+         if (zstandard > 0) then
+#ifdef NC_ZSTANDARD
+            call nchandle_error(nf90_def_var_zstandard(ncid, varID, zstandard))
+#else
+            STOP "Tried to set netCDF zstandard compression, but it is not available."
+#endif
+         else if (deflate > 0) then
+            call nchandle_error(nf90_def_var_deflate(ncid,varID, 0, 1, deflate_level = deflate))
+         end if
       end if
+
       call nchandle_error(nf90_put_att(ncID,VarID,'long_name',sx(n,2)))
       call nchandle_error(nf90_put_att(ncID,VarID,'units',sx(n,3)))
       call nchandle_error(nf90_put_att(ncid, VarID, '_FillValue',nc_fillvalue))


### PR DESCRIPTION
new namelist variable NAMNETCDFSTATS/zstandard, default = 0 meaning off. If zstandard is non-zero, enable zstandard compression for netcdf. If zstandard is set, it takes precedence over deflate, which is enabled by default.

Requirements:
* netcdf4 >~ 4.9.2 with zstandard support
* netcdf-fortran >= 4.6.2
* netcdf-fortran installed with the "plugin directory" set.
* DALES compiled with the cmake flag -DENABLE_ZSTANDARD=ON
* saving to the netcdf4 format (lclassic = .false.),

With the cmake flag set, netcdf-fortran >= 4.6.2
is required at compile time. If zstandard is set in the namelist, the other conditions are required,
otherwise a run-time error will occur.