### PR TITLE
modsurface: change lmostlocal to .true. by default

### DIFF
--- a/src/modsurfdata.f90
+++ b/src/modsurfdata.f90
@@ -209,7 +209,7 @@ SAVE
   real              :: gDav = -1
 
   ! Turbulent exchange variables
-  logical           :: lmostlocal  = .true.  !<  Switch to apply MOST locally to get local Obukhov length
+  logical           :: lmostlocal  = .true.   !<  Switch to apply MOST locally to get local Obukhov length
   logical           :: lsmoothflux = .false.  !<  Create uniform sensible and latent heat flux over domain
   logical           :: lneutral    = .false.  !<  Disable stability corrections
   real, allocatable :: obl   (:,:)            !<  Obukhov length [m]

--- a/src/modsurfdata.f90
+++ b/src/modsurfdata.f90
@@ -209,7 +209,7 @@ SAVE
   real              :: gDav = -1
 
   ! Turbulent exchange variables
-  logical           :: lmostlocal  = .false.  !<  Switch to apply MOST locally to get local Obukhov length
+  logical           :: lmostlocal  = .true.  !<  Switch to apply MOST locally to get local Obukhov length
   logical           :: lsmoothflux = .false.  !<  Create uniform sensible and latent heat flux over domain
   logical           :: lneutral    = .false.  !<  Disable stability corrections
   real, allocatable :: obl   (:,:)            !<  Obukhov length [m]


### PR DESCRIPTION
reason: with large domains with some heterogeneity, e.g. with open boundaries or cold pools, there may be large deviations in the local wind speed from the domain average. Using the local wind by default is less surprising than using the domain average.