### PR TITLE
Move Poisson solver namelist and data

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,7 @@ set( dales_srcs
 	modnudgeboundary.f90
 	modnvtx.f90
 	modopenboundary.f90
+	modpois_data.f90
 	modpois.f90
 	modprecision.f90
 	modquadrant.f90

--- a/src/modbudget.f90
+++ b/src/modbudget.f90
@@ -220,7 +220,7 @@ contains
                           dxi,dyi,dx2i,dy2i
     use modsurfdata,only : ustar
     use modsubgriddata, only : ekm,anis_fac
-    use modpois,    only : p
+    use modpois_data,    only : p
     use modfields,  only : u0,v0,w0,thv0h,u0av,v0av,rhobf,rhobh,thvh
 !cstep    use modtilt,    only : adjustbudget,ltilted
     use modmpi,     only : comm3d,mpi_sum,mpierr, D_MPI_ALLREDUCE

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -151,32 +151,6 @@ save
       logical :: lconstexner = .false.  !<  switch to use the initial pressure profile in the exner function
       logical :: lbaseexner = .false.   !<  switch to use the base pressure profile in the exner function
 
-      ! Poisson solver: modpois / modhypre
-      ! set default solver, can be overridden in namoptions
-#if defined(DALES_GPU)
-      integer :: solver_id = 200 ! cufft (default if OpenACC is used)
-#elif defined(USE_FFTW)
-      integer :: solver_id = 100 ! FFTW  (default if FFTW library compiled in and not on GPU)
-#else
-      integer :: solver_id = 0   ! Built-in FFT
-#endif
-                                     ! solver_id:                           0    1   2     3       4      100    200
-                                     !                                     FFT  SMG PFMG BiCGSTAB GMRES  FFTW  cufft
-      integer :: maxiter = 10000     ! Number of iterations                 .    X   X     X       X
-      real(real64):: tolerance = 1E-8! Convergence threshold                .    X   X     X       X
-      integer :: n_pre = 1           ! Number of pre and post relaxations   .    X   X     X       X
-      integer :: n_post =1           ! Number of pre and post relaxations   .    X   X     X       X
-      integer :: precond_id = 1      ! Preconditioner ID                    .    .  12   0189     0189
-      integer :: maxiter_precond = 1 ! Number of iterations for precondition per iteration
-      integer :: hypre_logging = 1   ! HYPRE logging and print level - set higher value for more messages
-      type solver_type
-         !integer*8 solver,precond
-        type(c_ptr) solver, precond
-        integer   solver_id, precond_id, maxiter, n_post, n_pre, maxiter_precond
-        real      tolerance
-      end type
-      type(solver_type) :: psolver
-
       ! Global variables (modvar.f90)
       integer :: xyear  = 0     !<     * year, only for time units in netcdf
       real :: xday      = 1.    !<     * day number

--- a/src/modhypre.f90
+++ b/src/modhypre.f90
@@ -25,9 +25,10 @@ use iso_c_binding
 use modprecision, only : pois_r, real64
 use modmpi, only : myid, myidx, myidy, nprocx, nprocy, MPI_COMM_WORLD &
                  , MPI_Wtime
-use modglobal, only : i1, j1, ih, jh, imax, jmax, kmax, solver_id, maxiter &
-                    , n_pre, n_post, tolerance, dzf, dzh, dx, dy &
-                    , itot, jtot, solver_type, hypre_logging
+use modglobal,      only: itot, jtot, imax, jmax, kmax, i1, j1, ih, jh, dx, &
+                          dy, dzf, dzh
+use modpois_data, only: solver_id, maxiter, n_pre, n_post, tolerance, &
+                          solver_type, hypre_logging
 use modfields, only : rhobf, rhobh
 implicit none
 

--- a/src/modnamelist.f90
+++ b/src/modnamelist.f90
@@ -4,6 +4,7 @@ module modnamelist
   use modaerosol,      only: aerosol_read_namelist
   use modchecksim,     only: checksim_read_namelist
   use modmicrophysics, only: microphysics_read_namelist
+  use modpois,         only: poisson_solver_read_namelist
 
   implicit none
 
@@ -19,6 +20,7 @@ contains
     character(len=*), intent(in) :: nml_filename
 
     ! Core modules
+    call poisson_solver_read_namelist(nml_filename)
     call checksim_read_namelist(nml_filename)
 
     ! Add-on modules

--- a/src/modopenboundary.f90
+++ b/src/modopenboundary.f90
@@ -43,7 +43,8 @@ contains
   subroutine initopenboundary
     ! Initialisation routine for openboundaries
     use modmpi, only : myidx, myidy, nprocx, nprocy, myid
-    use modglobal, only : imax,jmax,kmax,i1,j1,k1,dx,dy,itot,jtot,solver_id,nsv,cu,cv,dzf
+    use modglobal, only : imax,jmax,kmax,i1,j1,k1,dx,dy,itot,jtot,nsv,cu,cv,dzf
+    use modpois_data, only: solver_id
     use modboundary, only: dsv
     use modfields, only: rhobf
     implicit none

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -51,6 +51,15 @@ contains
     namelist /solver/ solver_id, maxiter, tolerance, n_pre, n_post, &
       precond_id, maxiter_precond, hypre_logging
 
+    ! Set a default solver based on how DALES is compiled.
+#if defined(DALES_GPU)
+    solver_id = 200
+#elif defined(USE_FFTW)
+    solver_id = 100
+#else
+    solver_id = 0
+#endif
+
     if (myid == 0) then
       open(ifnamopt, file=nml_filename, status='old', iostat=ierr)
       read(ifnamopt, solver, iostat=ierr)

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -28,28 +28,17 @@
 !
 
 module modpois
-use modglobal,    only : solver_id, maxiter, tolerance, n_pre, n_post, &
-                         precond_id, maxiter_precond, hypre_logging, ifnamopt, &
-                         checknamelisterror
+use modglobal,    only : ifnamopt, checknamelisterror
 use modmpi,       only : myid, commwrld, d_mpi_bcast
 use modprecision, only : pois_r
+use modpois_data, only: p, Fp, d, xyrt, pup, pvp, pwp, a, b, c, ps, pe, qs, &
+                          qe, maxiter, tolerance, n_pre, n_post, precond_id, &
+                          maxiter_precond, hypre_logging, psolver, solver_id
 use modtimer
 implicit none
 private
-public :: initpois,poisson,exitpois,p,Fp,xyrt,solmpj,ps,pe,qs,qe
+public :: initpois,poisson,exitpois
 public :: poisson_solver_read_namelist
-
-save
-
-  real(pois_r), pointer     :: p(:,:,:)    ! pressure fluctuations in real space
-  real(pois_r), pointer     :: Fp(:,:,:)   ! pressure fluctuations in fourier space
-  real(pois_r), allocatable :: d(:,:,:)    ! work array for tridiagonal solver
-  real(pois_r), allocatable :: xyrt(:,:)   ! constant factors in the poisson equation
-
-  integer :: ps,pe,qs,qe           ! start and end index of fourier space matrices
-
-  real(pois_r), allocatable :: pup(:,:,:), pvp(:,:,:), pwp(:,:,:) ! Work arrays for rhs
-  real(pois_r), allocatable :: a(:), b(:), c(:) ! Work arrays for solver
 
 contains
 
@@ -80,7 +69,7 @@ contains
   end subroutine poisson_solver_read_namelist
 
   subroutine initpois
-    use modglobal, only : solver_id,i1,j1,ih,jh,k1,kmax,solver_id,maxiter,tolerance,precond_id,n_pre,n_post,psolver,maxiter_precond
+    use modglobal, only : i1,j1,ih,jh,k1,kmax
     use modfft2d, only : fft2dinit
     use modfftw, only : fftwinit
     use modhypre, only : inithypre_grid, inithypre_solver
@@ -128,7 +117,6 @@ contains
   end subroutine initpois
 
   subroutine exitpois
-    use modglobal, only : solver_id,psolver
     use modfft2d, only : fft2dexit
     use modhypre, only : exithypre_grid, exithypre_solver
     use modfftw, only : fftwexit
@@ -155,7 +143,6 @@ contains
   end subroutine exitpois
 
   subroutine poisson
-    use modglobal, only : solver_id,psolver
     use modmpi, only : myid
     use modhypre, only : solve_hypre, set_zero_guess
     use modfftw, only : fftwf, fftwb

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -28,11 +28,16 @@
 !
 
 module modpois
+use modglobal,    only : solver_id, maxiter, tolerance, n_pre, n_post, &
+                         precond_id, maxiter_precond, hypre_logging, ifnamopt, &
+                         checknamelisterror
+use modmpi,       only : myid, commwrld, d_mpi_bcast
 use modprecision, only : pois_r
 use modtimer
 implicit none
 private
 public :: initpois,poisson,exitpois,p,Fp,xyrt,solmpj,ps,pe,qs,qe
+public :: poisson_solver_read_namelist
 
 save
 
@@ -47,6 +52,32 @@ save
   real(pois_r), allocatable :: a(:), b(:), c(:) ! Work arrays for solver
 
 contains
+
+  subroutine poisson_solver_read_namelist(nml_filename)
+
+    character(len=*), intent(in) :: nml_filename !< Name of namelist file.
+
+    integer :: ierr !< Error code.
+
+    namelist /solver/ solver_id, maxiter, tolerance, n_pre, n_post, &
+      precond_id, maxiter_precond, hypre_logging
+
+    if (myid == 0) then
+      open(ifnamopt, file=nml_filename, status='old', iostat=ierr)
+      read(ifnamopt, solver, iostat=ierr)
+      call checknamelisterror(ierr, ifnamopt, 'solver')
+      close(ifnamopt)
+    end if
+
+    call d_mpi_bcast(solver_id, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(maxiter, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(n_pre, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(n_post, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(tolerance, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(precond_id, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(maxiter_precond, 1, 0, commwrld, ierr)
+
+  end subroutine poisson_solver_read_namelist
 
   subroutine initpois
     use modglobal, only : solver_id,i1,j1,ih,jh,k1,kmax,solver_id,maxiter,tolerance,precond_id,n_pre,n_post,psolver,maxiter_precond

--- a/src/modpois_data.f90
+++ b/src/modpois_data.f90
@@ -1,0 +1,44 @@
+!> Common declarations for FFT-based and HYPRE Poisson solvers.
+module modpois_data
+  
+  use, intrinsic :: iso_c_binding
+
+  use modprecision, only: real64, pois_r
+
+  implicit none
+
+  integer :: solver_id = 0
+
+  real(pois_r), pointer     :: p(:,:,:)  !< Pressure fluctuations in real space.
+  real(pois_r), pointer     :: Fp(:,:,:) !< Pressure fluctuations in Fourier space.
+  real(pois_r), allocatable :: d(:,:,:)  !< Work array for tridiagonal solver.
+  real(pois_r), allocatable :: xyrt(:,:) !< Eigenvalues.
+
+  real(pois_r), allocatable :: pup(:,:,:) !< Work array for rhs.
+  real(pois_r), allocatable :: pvp(:,:,:) !< Work array for rhs.
+  real(pois_r), allocatable :: pwp(:,:,:) !< Work array for rhs.
+  real(pois_r), allocatable :: a(:)       !< Work array for solver.
+  real(pois_r), allocatable :: b(:)       !< Work array for solver.
+  real(pois_r), allocatable :: c(:)       !< Work array for solver.
+
+  integer :: ps, pe, qs, qe !< Start and end indices of Fourier space matrices.
+
+  ! HYPRE-specific variables
+  integer      :: maxiter = 10000     !< Number of iterations.
+  real(real64) :: tolerance = 1E-8    !< Convergence threshold.
+  integer      :: n_pre = 1           !< Number of pre relaxations.
+  integer      :: n_post = 1          !< Number of post relaxations.
+  integer      :: precond_id = 1      !< Preconditioner ID.
+  integer      :: maxiter_precond = 1 !< Number of iterations for preconditioner.
+  integer      :: hypre_logging = 1   !< HYPRE logging and print level.
+
+  type solver_type
+    type(c_ptr)  :: solver, precond
+    integer      :: solver_id, precond_id, maxiter, n_post, n_pre, &
+                    maxiter_precond
+    real(real64) :: tolerance
+  end type
+
+  type(solver_type) :: psolver
+
+end module modpois_data

--- a/src/modsampling.f90
+++ b/src/modsampling.f90
@@ -384,7 +384,7 @@ contains
                           sv0,wp
     use modsubgriddata,only : ekh,ekm
     use modmpi,    only : slabsum,comm3d,mpierr,mpi_sum,D_MPI_ALLREDUCE
-    use modpois,   only : p
+    use modpois_data,   only : p
     use modmicrodata, only : imicro, imicro_bulk, imicro_bin, imicro_sice
     use modtracers,  only : get_tracer_index
     implicit none

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -76,11 +76,11 @@ contains
                                   ifnamopt,fname_options,llsadv,lconstexner,lbaseexner, &
                                   ibas_prf,lambda_crit,iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv,courant,peclet,ladaptive,author,&
                                   lnoclouds,lfast_thermo,lrigidlid,unudge,ntimedep,&
-                                  solver_id, maxiter, maxiter_precond, tolerance, n_pre, n_post, precond_id, checknamelisterror, &
+                                  checknamelisterror, &
                                   loutdirs, output_prefix, &
                                   lopenbc,linithetero,lperiodic,dxint,dyint,dzint,dxturb,dyturb,taum,tauh,pbc,&
                                   lsynturb,nmodes,tau,lambda,lambdas,lambdas_x,lambdas_y,lambdas_z,iturb, &
-                                  hypre_logging,rdt,rk3step,i1,j1,k1,ih,jh,lboundary,iinput,dzf
+                                  rdt,rk3step,i1,j1,k1,ih,jh,lboundary,iinput,dzf
     use modforces,         only : lforce_user
     use modsurfdata,       only : z0,ustin,wtsurf,wqsurf,wsvsurf,ps,thls,isurf
     use modsurface,        only : initsurface

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -143,8 +143,6 @@ contains
         rka,dlwtop,dlwbot,sw0,gc,reff,isvsmoke,lforce_user,lcloudshading,lrigidlid,unudge,lfast_thermo,lconstexner,lbaseexner
     namelist/DYNAMICS/ &
         llsadv,  lqlnr, lambda_crit, cu, cv, ibas_prf, iadv_mom, iadv_tke, iadv_thl, iadv_qt, iadv_sv, lnoclouds
-    namelist/SOLVER/ &
-        solver_id, maxiter, tolerance, n_pre, n_post, precond_id, maxiter_precond, hypre_logging
     namelist/OPENBC/ &
         lopenbc,linithetero,lper,lbuoytop,dxint,dyint,dzint,dxturb,dyturb,taum,tauh,pbc,lsynturb,iturb,tau,lambda,nmodes,lambdas,lambdas_x,lambdas_y,lambdas_z,lbuoytop
 
@@ -184,10 +182,6 @@ contains
       read (ifnamopt,DYNAMICS,iostat=ierr)
       call checknamelisterror(ierr, ifnamopt, 'DYNAMICS')
       write(6 ,DYNAMICS)
-      rewind(ifnamopt)
-      read (ifnamopt,SOLVER,iostat=ierr)
-      call checknamelisterror(ierr, ifnamopt, 'SOLVER')
-      write(6 ,SOLVER)
       rewind(ifnamopt)
       read (ifnamopt,OPENBC,iostat=ierr)
       call checknamelisterror(ierr, ifnamopt, 'OPENBC')
@@ -318,14 +312,6 @@ contains
     call D_MPI_BCAST(iadv_sv ,1,0,commwrld,mpierr)
 
     call D_MPI_BCAST(lnoclouds  ,1,0,commwrld,mpierr)
-
-    call D_MPI_BCAST(solver_id,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(maxiter,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(n_pre,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(n_post,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(tolerance,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(precond_id,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(maxiter_precond,1,0,commwrld,mpierr)
 
     ! Broadcast openboundaries Variables
     call D_MPI_BCAST(lopenbc,    1, 0,commwrld,mpierr)


### PR DESCRIPTION
Small cleanup

- Moved data for the Poisson solver from `modglobal` to a new module `modpois_data`
- Added subroutine for reading solver namelist, called from `read_namelists`