### PR TITLE
Fix infinite CMake loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,7 @@ ecbuild_add_option( FEATURE RRTMG
 
 ecbuild_find_package( NetCDF REQUIRED COMPONENTS Fortran C )
 
-ecbuild_find_mpi( COMPONENTS Fortran REQUIRED )
-ecbuild_info( "MPI compiler: ${MPI_Fortran_COMPILER}")
-set ( CMAKE_Fortran_COMPILER ${MPI_Fortran_COMPILER} )
+ecbuild_find_package( MPI REQUIRED COMPONENTS Fortran )
 
 # Set precision
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -251,6 +251,7 @@ ecbuild_add_executable( TARGET dales
                           ${NetCDF_Fortran_INCLUDE_DIR}
                           $<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
                         LIBS
+                          MPI::MPI_Fortran
                           NetCDF::NetCDF_Fortran
                           NetCDF::NetCDF_C
 													fortran-support::fortran-support
@@ -279,6 +280,7 @@ ecbuild_add_library( TARGET libdales
                        ${NetCDF_Fortran_INCLUDE_DIR}
                        $<$<BOOL:${ENABLE_FFTW}>:${FFTW_INCLUDE_DIRS}>
                      PUBLIC_LIBS
+                       MPI::MPI_Fortran
                        NetCDF::NetCDF_Fortran
                        $<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3>
                        $<$<BOOL:${ENABLE_FFTW}>:FFTW::fftw3f>


### PR DESCRIPTION
Previously, we (I) set the Fortran compiler to `mpif90` from within our CMake project. Aside from being bad practice, this is causing issues with subprojects (Fortran support) which reset the compiler to the one provided on the command line.