### PR TITLE
Introduce namelist for thermodynamics

### DIFF
--- a/cases/GOAMAZON14/ControlExperiment/input/namoptions.047
+++ b/cases/GOAMAZON14/ControlExperiment/input/namoptions.047
@@ -119,7 +119,6 @@ wsvsurf(19) = 0.0
 wsvsurf(20) = 0.0
 wsvsurf(21) = 0.0
 
-lmoist     =  .true.
 iradiation =  4
 
 lcoriol    =  .true.

--- a/cases/GOAMAZON14/TransparentClouds/input/namoptions.060
+++ b/cases/GOAMAZON14/TransparentClouds/input/namoptions.060
@@ -119,7 +119,6 @@ wsvsurf(19) = 0.0
 wsvsurf(20) = 0.0
 wsvsurf(21) = 0.0
 
-lmoist     =  .true.
 iradiation =  4
 
 lcoriol    =  .true.

--- a/cases/arm_brown/namoptions.001
+++ b/cases/arm_brown/namoptions.001
@@ -26,7 +26,6 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .true.
 lcoriol    =  .true.
 ltimedep   =  .true.
 /

--- a/cases/arm_unstable/namoptions.001
+++ b/cases/arm_unstable/namoptions.001
@@ -26,7 +26,6 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .true.
 lcoriol    =  .true.
 ltimedep   =  .true.
 /

--- a/cases/atex/namoptions.001
+++ b/cases/atex/namoptions.001
@@ -26,7 +26,6 @@ ysize      =  6400
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  2
 dlwtop     = 74
 dlwbot     = 0

--- a/cases/benchmark/GOAMAZON14/namoptions.047
+++ b/cases/benchmark/GOAMAZON14/namoptions.047
@@ -119,7 +119,6 @@ wsvsurf(19) = 0.0
 wsvsurf(20) = 0.0
 wsvsurf(21) = 0.0
 
-lmoist     =  .true.
 iradiation =  4
 
 lcoriol    =  .true.

--- a/cases/benchmark/cao/namoptions.196
+++ b/cases/benchmark/cao/namoptions.196
@@ -28,7 +28,6 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  4
 timerad    =  60.
 lcoriol    =  .true.
@@ -70,7 +69,6 @@ timeav          =  600
 
 &DYNAMICS
 llsadv     =  .false.
-lqlnr      =  .false.
 cu         =  2
 cv         =  -18
 
@@ -79,6 +77,9 @@ iadv_tke    =  52
 iadv_thl    =  52
 iadv_qt     =  52
 iadv_sv     =  52
+/
+&THERMODYNAMICS
+lqlnr       = .false.
 /
 &NAMCHECKSIM
 tcheck      = 0

--- a/cases/benchmark/rico/namoptions-144.001
+++ b/cases/benchmark/rico/namoptions-144.001
@@ -29,7 +29,6 @@ xtime      =  0.0
 /
 
 &PHYSICS
-lmoist     =  .true.
 irad       =  0
 timerad    =  2
 lcoriol    =  .true.
@@ -49,7 +48,6 @@ z0hav =  3.2e-5
 
 &DYNAMICS
 llsadv     =  .false.
-lqlnr      =  .false.
 cu         =  -5.
 cv         =  -4.
 
@@ -58,6 +56,9 @@ iadv_tke   =  2
 iadv_thl   =  2
 iadv_qt    =  2
 iadv_sv    =  7
+/
+&THERMODYNAMICS
+lqlnr       = .false.
 /
 &NAMMICROPHYSICS
 imicro     = 2

--- a/cases/benchmark/rico/namoptions-1728.001
+++ b/cases/benchmark/rico/namoptions-1728.001
@@ -29,7 +29,6 @@ xtime      =  0.0
 /
 
 &PHYSICS
-lmoist     =  .true.
 irad       =  0
 timerad    =  2
 lcoriol    =  .true.
@@ -49,7 +48,6 @@ z0hav =  3.2e-5
 
 &DYNAMICS
 llsadv     =  .false.
-lqlnr      =  .false.
 cu         =  -5.
 cv         =  -4.
 
@@ -58,6 +56,9 @@ iadv_tke   =  2
 iadv_thl   =  2
 iadv_qt    =  2
 iadv_sv    =  7
+/
+&THERMODYNAMICS
+lqlnr       = .false.
 /
 &NAMMICROPHYSICS
 imicro     = 2

--- a/cases/benchmark/rico/namoptions-432.001
+++ b/cases/benchmark/rico/namoptions-432.001
@@ -34,7 +34,6 @@ xtime      =  0.0
 /
 
 &PHYSICS
-lmoist     =  .true.
 irad       =  0
 timerad    =  2
 lcoriol    =  .true.
@@ -54,7 +53,6 @@ z0hav =  3.2e-5
 
 &DYNAMICS
 llsadv     =  .false.
-lqlnr      =  .false.
 cu         =  -5.
 cv         =  -4.
 
@@ -63,6 +61,9 @@ iadv_tke   =  2
 iadv_thl   =  2
 iadv_qt    =  2
 iadv_sv    =  7
+/
+&THERMODYNAMICS
+lqlnr       = .false.
 /
 &NAMMICROPHYSICS
 imicro     = 2

--- a/cases/benchmark/rico/namoptions-864.001
+++ b/cases/benchmark/rico/namoptions-864.001
@@ -34,7 +34,6 @@ xtime      =  0.0
 /
 
 &PHYSICS
-lmoist     =  .true.
 irad       =  0
 timerad    =  2
 lcoriol    =  .true.
@@ -54,7 +53,6 @@ z0hav =  3.2e-5
 
 &DYNAMICS
 llsadv     =  .false.
-lqlnr      =  .false.
 cu         =  -5.
 cv         =  -4.
 
@@ -63,6 +61,9 @@ iadv_tke   =  2
 iadv_thl   =  2
 iadv_qt    =  2
 iadv_sv    =  7
+/
+&THERMODYNAMICS
+lqlnr       = .false.
 /
 &NAMMICROPHYSICS
 imicro     = 2

--- a/cases/benchmark/rico/namoptions-fixed.001
+++ b/cases/benchmark/rico/namoptions-fixed.001
@@ -28,7 +28,6 @@ xtime      =  0.0
 /
 
 &PHYSICS
-lmoist     =  .true.
 irad       =  0
 timerad    =  2
 lcoriol    =  .true.
@@ -48,7 +47,6 @@ z0hav =  3.2e-5
 
 &DYNAMICS
 llsadv     =  .false.
-lqlnr      =  .false.
 cu         =  -5.
 cv         =  -4.
 
@@ -57,6 +55,9 @@ iadv_tke   =  2
 iadv_thl   =  2
 iadv_qt    =  2
 iadv_sv    =  7
+/
+&THERMODYNAMICS
+lqlnr       = .false.
 /
 &NAMMICROPHYSICS
 imicro     = 2

--- a/cases/benchmark/ruisdael/namoptions-1728.001
+++ b/cases/benchmark/ruisdael/namoptions-1728.001
@@ -30,7 +30,6 @@ xtime  = 12
 /
 
 &PHYSICS
-lmoist = .true.
 lcoriol = .false.
 ltimedep = .true.
 iradiation = 4      ! 4 = RRTMG

--- a/cases/benchmark/ruisdael/namoptions-192.001
+++ b/cases/benchmark/ruisdael/namoptions-192.001
@@ -30,7 +30,6 @@ xtime  = 12
 /
 
 &PHYSICS
-lmoist = .true.
 lcoriol = .false.
 ltimedep = .true.
 iradiation = 4      ! 4 = RRTMG

--- a/cases/benchmark/ruisdael/namoptions-96.001
+++ b/cases/benchmark/ruisdael/namoptions-96.001
@@ -30,7 +30,6 @@ xtime  = 12
 /
 
 &PHYSICS
-lmoist = .true.
 lcoriol = .false.
 ltimedep = .true.
 iradiation = 4      ! 4 = RRTMG

--- a/cases/bomex/namoptions.001
+++ b/cases/bomex/namoptions.001
@@ -26,7 +26,6 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .true.
 lcoriol    =  .true.
 /
 &NAMSURFACE

--- a/cases/botany-dephy/namoptions.001
+++ b/cases/botany-dephy/namoptions.001
@@ -29,7 +29,6 @@ xtime      =  0.0
 /
 
 &PHYSICS
-lmoist     =  .true.
 timerad    =  60
 iradiation =  4
 lcoriol    =  .true.

--- a/cases/botany/namoptions-1536.001
+++ b/cases/botany/namoptions-1536.001
@@ -31,7 +31,6 @@ xtime      =  0.0
 /
 
 &PHYSICS
-lmoist     =  .true.
 timerad    =  60
 iradiation =  4
 lcoriol    =  .true.

--- a/cases/cblstrong/namoptions.001
+++ b/cases/cblstrong/namoptions.001
@@ -25,10 +25,13 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .false.
 iradiation =  0
 timerad    =  3600
 lcoriol    =  .false.
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMSURFACE

--- a/cases/cblweak/namoptions.001
+++ b/cases/cblweak/namoptions.001
@@ -25,10 +25,13 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .false.
 iradiation =  0
 timerad    =  3600
 lcoriol    =  .false.
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMSURFACE

--- a/cases/cldveg01/model_data/ASYM/namoptions.600
+++ b/cases/cldveg01/model_data/ASYM/namoptions.600
@@ -48,8 +48,6 @@ sgs_surface_fix = .false.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/ASYM/namoptions.620
+++ b/cases/cldveg01/model_data/ASYM/namoptions.620
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/ASYM/namoptions.630
+++ b/cases/cldveg01/model_data/ASYM/namoptions.630
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/ASYM/namoptions.640
+++ b/cases/cldveg01/model_data/ASYM/namoptions.640
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/ASYM/namoptions.650
+++ b/cases/cldveg01/model_data/ASYM/namoptions.650
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/DOMAIN/namoptions.208
+++ b/cases/cldveg01/model_data/DOMAIN/namoptions.208
@@ -51,8 +51,6 @@ sgs_surface_fix = .false.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/DOMAIN/namoptions.228
+++ b/cases/cldveg01/model_data/DOMAIN/namoptions.228
@@ -51,8 +51,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/DOMAIN/namoptions.238
+++ b/cases/cldveg01/model_data/DOMAIN/namoptions.238
@@ -51,8 +51,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/DOMAIN/namoptions.248
+++ b/cases/cldveg01/model_data/DOMAIN/namoptions.248
@@ -51,8 +51,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/DOMAIN/namoptions.258
+++ b/cases/cldveg01/model_data/DOMAIN/namoptions.258
@@ -51,8 +51,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/INST/namoptions.200
+++ b/cases/cldveg01/model_data/INST/namoptions.200
@@ -48,8 +48,6 @@ sgs_surface_fix = .false.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/INST/namoptions.220
+++ b/cases/cldveg01/model_data/INST/namoptions.220
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/INST/namoptions.230
+++ b/cases/cldveg01/model_data/INST/namoptions.230
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/INST/namoptions.240
+++ b/cases/cldveg01/model_data/INST/namoptions.240
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/INST/namoptions.250
+++ b/cases/cldveg01/model_data/INST/namoptions.250
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/TRANS/namoptions.100
+++ b/cases/cldveg01/model_data/TRANS/namoptions.100
@@ -48,8 +48,6 @@ sgs_surface_fix = .false.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/TRANS/namoptions.120
+++ b/cases/cldveg01/model_data/TRANS/namoptions.120
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/TRANS/namoptions.130
+++ b/cases/cldveg01/model_data/TRANS/namoptions.130
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/TRANS/namoptions.140
+++ b/cases/cldveg01/model_data/TRANS/namoptions.140
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/cldveg01/model_data/TRANS/namoptions.150
+++ b/cases/cldveg01/model_data/TRANS/namoptions.150
@@ -48,8 +48,6 @@ sgs_surface_fix = .true.
 /
 
 &DYNAMICS
-lqlnr      =  .true.
-lnoclouds  =  .false.
 cu         =  0
 cv         =  0.
 

--- a/cases/deep-botany/namoptions.001
+++ b/cases/deep-botany/namoptions.001
@@ -33,7 +33,6 @@
 
 &physics
     igrw_damp = 2
-    lfast_thermo = .true.
     iradiation = 4
     timerad = 60
     lcoriol = .true.

--- a/cases/dycoms_rf02/namoptions.001
+++ b/cases/dycoms_rf02/namoptions.001
@@ -26,7 +26,6 @@ xtime      =  15.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  10
 
 timerad    =  0

--- a/cases/example/input/namoptions.001
+++ b/cases/example/input/namoptions.001
@@ -25,7 +25,6 @@ xtime      =  10.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  0
 useMcICA   =  .true.
 lcoriol    =  .true.

--- a/cases/example/input/namoptions.lsm
+++ b/cases/example/input/namoptions.lsm
@@ -30,7 +30,6 @@ ps         =  100000.00
 thls       =  296.
 wtsurf     =  0.1
 wqsurf     =  0.0001
-lmoist     =  .true.
 isurf      =  1
 iradiation =  3
 useMcICA   =  .true.

--- a/cases/example/input/namoptions.lsmrad
+++ b/cases/example/input/namoptions.lsmrad
@@ -30,7 +30,6 @@ ps         =  100000.00
 thls       =  296.
 wtsurf     =  0.1
 wqsurf     =  0.0001
-lmoist     =  .true.
 isurf      =  1
 iradiation =  1
 useMcICA   =  .true.

--- a/cases/example/inputwindnoneq/namoptions.001
+++ b/cases/example/inputwindnoneq/namoptions.001
@@ -25,7 +25,6 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  0
 timerad    =  3600
 lcoriol    =  .true.

--- a/cases/example/namoptions.001
+++ b/cases/example/namoptions.001
@@ -25,7 +25,6 @@ xtime      =  10.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  0
 useMcICA   =  .true.
 lcoriol    =  .true.

--- a/cases/example/namoptions.lsm
+++ b/cases/example/namoptions.lsm
@@ -25,7 +25,6 @@ xtime      =  8.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  3
 useMcICA   =  .true.
 lcoriol    =  .true.

--- a/cases/example/namoptions.lsmrad
+++ b/cases/example/namoptions.lsmrad
@@ -25,7 +25,6 @@ xtime      =  8.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  1
 useMcICA   =  .true.
 lcoriol    =  .true.

--- a/cases/fog/namoptions.001
+++ b/cases/fog/namoptions.001
@@ -26,7 +26,6 @@ xtime      =  0.
 /
 
 &PHYSICS
-lmoist     =  .true.
 iradiation =  1
 useMcICA   =  .true.
 lcoriol    =  .true.

--- a/cases/gabls1/namoptions.001
+++ b/cases/gabls1/namoptions.001
@@ -26,9 +26,12 @@ xtime      =  0.
 
 &PHYSICS
 ltimedep   =  .true.
-lmoist     =  .false.
 iradiation =  0
 lcoriol    =  .true.
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMSURFACE

--- a/cases/gabls1/namoptions_SMAGORINKSY.001
+++ b/cases/gabls1/namoptions_SMAGORINKSY.001
@@ -26,9 +26,12 @@ xtime      =  0.
 
 &PHYSICS
 ltimedep   =  .true.
-lmoist     =  .false.
 iradiation =  0
 lcoriol    =  .true.
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMSURFACE

--- a/cases/heterogen/namoptions.841
+++ b/cases/heterogen/namoptions.841
@@ -70,7 +70,6 @@ wsvsurf(19) = 0.0
 wsvsurf(20) = 0.0
 
 
-lmoist     =  .true.
 irad       =  0
 timerad    =  3600
 lcoriol    =  .true.

--- a/cases/heterogen/namoptions.941
+++ b/cases/heterogen/namoptions.941
@@ -62,7 +62,6 @@ wsvsurf(19) = 0.0
 wsvsurf(20) = 0.0
 
 
-lmoist     =  .true.
 irad       =  0
 timerad    =  3600
 lcoriol    =  .true.

--- a/cases/hireslapse/namoptions.001
+++ b/cases/hireslapse/namoptions.001
@@ -27,7 +27,6 @@ xtime      =  4.
 &PHYSICS
 wsvsurf(1) =  0.
 wsvsurf(2) =  1.
-lmoist     =  .true.
 iradiation =  0
 useMcICA   =  .true.
 lcoriol    =  .true.

--- a/cases/lsm_ibm/namoptions.001
+++ b/cases/lsm_ibm/namoptions.001
@@ -28,7 +28,6 @@
 /
 
 &physics
-    lmoist = .true.
     lcoriol = .true.
     iradiation = 4
     timerad = 60

--- a/cases/neutral/namoptions.001
+++ b/cases/neutral/namoptions.001
@@ -25,11 +25,14 @@ xtime      =  4.
 /
 
 &PHYSICS
-lmoist     =  .false.
 iradiation =  0
 useMcICA   =  .true.
 lcoriol    =  .true.
 igrw_damp  =  0
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMNETCDFSTATS

--- a/cases/rico/namoptions.001
+++ b/cases/rico/namoptions.001
@@ -28,7 +28,6 @@ xtime      =  0.0
 &PHYSICS
 
 
-lmoist     =  .true.
 irad       =  0
 timerad    =  2
 lcoriol    =  .true.

--- a/cases/smoke/namoptions.001
+++ b/cases/smoke/namoptions.001
@@ -29,7 +29,6 @@ xtime      =  0.
 &PHYSICS
 !wsvsurf    =  0.0 ! since DALES 5.0 this goes in tracerdata.inp
 
-lmoist     =  .false.
 iradiation =  2
 rad_smoke  = .true.
 rad_longw  = .true.
@@ -41,6 +40,10 @@ isvsmoke   =  1
 rka        =  0.02
 igrw_damp  = 0
 
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMSURFACE

--- a/cases/sullivan2011/namoptions.001
+++ b/cases/sullivan2011/namoptions.001
@@ -25,9 +25,12 @@ xlon       =  0.
 
 &PHYSICS
 ltimedep   =  .false.
-lmoist     =  .false.
 lcoriol    =  .true.
 iradiation = 0
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMSURFACE

--- a/cases/sullivan2011/namoptions_SMAGORINSKY.001
+++ b/cases/sullivan2011/namoptions_SMAGORINSKY.001
@@ -25,9 +25,12 @@ xlon       =  0.
 
 &PHYSICS
 ltimedep   =  .false.
-lmoist     =  .false.
 lcoriol    =  .true.
 iradiation = 0
+/
+
+&THERMODYNAMICS
+lmoist     = .false.
 /
 
 &NAMSURFACE

--- a/src/daleslib.f90
+++ b/src/daleslib.f90
@@ -590,7 +590,8 @@ module daleslib
         ! update the surface pressure according to ps_tend
         ! perform the update every full timestep to avoid introducing ps0, psm
         subroutine update_ps
-          use modglobal,          only: rdt, rk3step, lmoist
+          use modglobal,          only: rdt, rk3step
+          use modthermodynamics,  only: lmoist
           use modsurfdata,        only : ps, qts
           use modsurface,         only : qtsurf
 

--- a/src/modadvection.f90
+++ b/src/modadvection.f90
@@ -34,7 +34,7 @@ contains
 !> Advection redirection function
 subroutine advection
 
-  use modglobal,      only : lmoist, nsv, iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv, &
+  use modglobal,      only : nsv, iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv, &
                              iadv_cd2,iadv_5th,iadv_52,iadv_cd6,iadv_62,iadv_kappa,&
                              iadv_upw,iadv_hybrid,iadv_hybrid_f,iadv_null,leq,&
                              lopenbc,lboundary,lperiodic,i1,j1
@@ -52,6 +52,7 @@ subroutine advection
   use advec_kappa,    only : hadvecc_kappa, vadvecc_kappa
   use advec_upw,      only : hadvecc_upw, vadvecc_upw
   use modopenboundary,only : advecc_2nd_boundary_buffer,advecu_2nd_boundary_buffer,advecv_2nd_boundary_buffer,advecw_2nd_boundary_buffer
+  use modthermodynamics, only: lmoist
   implicit none
   integer :: n,istart,iend,jstart,jend,ibuffer,jbuffer
   character(len=*), parameter :: routine = modname//'/advection'

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -147,12 +147,7 @@ save
 
       real :: lambda_crit=100. !< maximum value for the smoothness. This controls if WENO or
 
-      logical :: lmoist   = .true.  !<   switch to calculate moisture fields
-      logical :: lnoclouds = .false. !<   switch to enable/disable thl calculations
-      logical :: lfast_thermo = .true. !<   switch to enable faster icethermo scheme
       logical :: lsgbucorr= .false.  !<   switch to enable subgrid buoyancy flux
-      logical :: lconstexner = .false.  !<  switch to use the initial pressure profile in the exner function
-      logical :: lbaseexner = .false.   !<  switch to use the base pressure profile in the exner function
 
       ! Global variables (modvar.f90)
       integer :: xyear  = 0     !<     * year, only for time units in netcdf

--- a/src/modnamelist.f90
+++ b/src/modnamelist.f90
@@ -1,11 +1,12 @@
 !> Read namelists and check settings.
 module modnamelist
 
-  use modaerosol,      only: aerosol_read_namelist
-  use modchecksim,     only: checksim_read_namelist
-  use modmicrophysics, only: microphysics_read_namelist
-  use modpois,         only: poisson_solver_read_namelist
-  use modsurface,      only: surface_read_namelist
+  use modaerosol,        only: aerosol_read_namelist
+  use modchecksim,       only: checksim_read_namelist
+  use modmicrophysics,   only: microphysics_read_namelist
+  use modpois,           only: poisson_solver_read_namelist
+  use modsurface,        only: surface_read_namelist
+  use modthermodynamics, only: thermodynamics_read_namelist
 
   implicit none
 
@@ -21,6 +22,7 @@ contains
     character(len=*), intent(in) :: nml_filename
 
     ! Core modules
+    call thermodynamics_read_namelist(nml_filename)
     call surface_read_namelist(nml_filename)
     call poisson_solver_read_namelist(nml_filename)
     call checksim_read_namelist(nml_filename)

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -73,10 +73,10 @@ contains
     use modglobal,         only : version,initglobal,iexpnr, ltotruntime, runtime, dtmax, dtav_glob,timeav_glob,&
                                   lwarmstart,startfile,trestart,&
                                   nsv,itot,jtot,kmax,xsize,ysize,xlat,xlon,xyear,xday,xtime,&
-                                  lmoist,lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,cu,cv,&
-                                  ifnamopt,fname_options,llsadv,lconstexner,lbaseexner, &
+                                  lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,cu,cv,&
+                                  ifnamopt,fname_options,llsadv, &
                                   ibas_prf,lambda_crit,iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv,courant,peclet,ladaptive,author,&
-                                  lnoclouds,lfast_thermo,lrigidlid,unudge,ntimedep,&
+                                  lrigidlid,unudge,ntimedep,&
                                   checknamelisterror, &
                                   loutdirs, output_prefix, &
                                   lopenbc,linithetero,lperiodic,dxint,dyint,dzint,dxturb,dyturb,taum,tauh,pbc,&
@@ -138,12 +138,11 @@ contains
         xlat,xlon,xyear,xday,xtime,ksp
     namelist/PHYSICS/ &
         !cstep z0,ustin,wtsurf,wqsurf,wsvsurf,ps,thls,chi_half,lmoist,isurf,lneutraldrag,&
-        lmoist,chi_half,&
         lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,ltimedep,ltimedepuv,ltimedepsv,ntimedep,&
         irad,timerad,iradiation,rad_ls,rad_longw,rad_shortw,rad_smoke,useMcICA,&
-        rka,dlwtop,dlwbot,sw0,gc,reff,isvsmoke,lforce_user,lcloudshading,lrigidlid,unudge,lfast_thermo,lconstexner,lbaseexner
+        rka,dlwtop,dlwbot,sw0,gc,reff,isvsmoke,lforce_user,lcloudshading,lrigidlid,unudge
     namelist/DYNAMICS/ &
-        llsadv,  lqlnr, lambda_crit, cu, cv, ibas_prf, iadv_mom, iadv_tke, iadv_thl, iadv_qt, iadv_sv, lnoclouds
+        llsadv, lambda_crit, cu, cv, ibas_prf, iadv_mom, iadv_tke, iadv_thl, iadv_qt, iadv_sv
     namelist/OPENBC/ &
         lopenbc,linithetero,lper,lbuoytop,dxint,dyint,dzint,dxturb,dyturb,taum,tauh,pbc,lsynturb,iturb,tau,lambda,nmodes,lambdas,lambdas_x,lambdas_y,lambdas_z,lbuoytop
 
@@ -241,8 +240,6 @@ contains
     call D_MPI_BCAST(xtime      ,1,0,commwrld,mpierr)
 
     !call D_MPI_BCAST(lneutraldrag ,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(chi_half    ,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(lmoist      ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(lcoriol     ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(lpressgrad  ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(igrw_damp   ,1,0,commwrld,mpierr)
@@ -255,9 +252,6 @@ contains
     call D_MPI_BCAST(ltimedepsv  ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(lrigidlid   ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(unudge      ,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(lfast_thermo,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(lconstexner ,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(lbaseexner  ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(irad       ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(timerad    ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(iradiation ,1,0,commwrld,mpierr)
@@ -300,8 +294,6 @@ contains
     call D_MPI_BCAST(iadv_thl,1,0,commwrld,mpierr)
     call D_MPI_BCAST(iadv_qt ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(iadv_sv ,1,0,commwrld,mpierr)
-
-    call D_MPI_BCAST(lnoclouds  ,1,0,commwrld,mpierr)
 
     ! Broadcast openboundaries Variables
     call D_MPI_BCAST(lopenbc,    1, 0,commwrld,mpierr)
@@ -510,8 +502,9 @@ contains
                                   rtimee,timee,ntrun,btime,dt_lim,nsv,&
                                   zf,dzf,dzh,rv,rd,cp,rlv,pref0,om23_gs,&
                                   ijtot,cu,cv,e12min,dzh,cexpnr,ifinput,lwarmstart,ltotruntime,itrestart,&
-                                  trestart, ladaptive,llsadv,tnextrestart,longint,lconstexner,lbaseexner,lopenbc,linithetero, &
+                                  trestart, ladaptive,llsadv,tnextrestart,longint,lopenbc,linithetero, &
                                   iinput, input_netcdf, input_ascii, lcoriol
+    use modthermodynamics, only : lconstexner,lbaseexner
     use modsubgrid,        only : ekm,ekh
     use modsurfdata,       only : wsvsurf, &
                                   thls,tskin,tskinm,tsoil,tsoilm,phiw,phiwm,Wl,Wlm,thvs,qts,isurf,svs,obl,oblav,&
@@ -1625,8 +1618,8 @@ contains
     ! In the current implementation, neither the base pressure, nor the base virtual temperature plays a role in the dynamics
     ! They are nevertheless calculated and printed to the stdin/baseprof files for user convenience
     use modfields,         only : rhobf,rhobh,drhobdzf,drhobdzh,exnf,exnh
-    use modglobal,         only : k1,kmax,zf,zh,dzf,dzh,rv,rd,grav,cp,pref0,lwarmstart,ibas_prf,cexpnr,ifinput,ifoutput,&
-                                  lbaseexner
+    use modglobal,         only : k1,kmax,zf,zh,dzf,dzh,rv,rd,grav,cp,pref0,lwarmstart,ibas_prf,cexpnr,ifinput,ifoutput
+    use modthermodynamics, only : lbaseexner
     use modsurfdata,       only : thls,ps,qts
     use modmpi,            only : myid,comm3d,mpierr,D_MPI_BCAST
     use modlogging,        only : profile_output
@@ -1947,7 +1940,7 @@ contains
 
   !> Check prognostic variables before simulation
   subroutine check_initial_state()
-    use modglobal, only: lmoist
+    use modthermodynamics, only: lmoist
     use modfields, only: u0, v0, w0, thl0, qt0, sv0
 
     ! Weird bug, casting thresholds to _field_r leads to compilation error for

--- a/src/modsubgrid.f90
+++ b/src/modsubgrid.f90
@@ -162,7 +162,8 @@ contains
    ! Diffusion subroutines
    ! Thijs Heus, Chiel van Heerwaarden, 15 June 2007
 
-    use modglobal,    only : nsv, lmoist, lopenbc, lboundary, lperiodic
+    use modglobal,    only : nsv, lopenbc, lboundary, lperiodic
+    use modthermodynamics, only: lmoist
     use modfields,    only : up,vp,wp,e12p,thl0,thlp,qt0,qtp,sv0,svp
     use modsurfdata,  only : thlflux,qtflux,svflux
 

--- a/src/modsynturb.f90
+++ b/src/modsynturb.f90
@@ -59,7 +59,8 @@ type(randomNumberSequence) :: noise
 contains
   subroutine initsynturb
     use netcdf
-    use modglobal, only : dx,dy,imax,jmax,i1,j1,lambdas,lambdas_x,lambdas_y,lambdas_z,kmax,k1,cexpnr,lmoist
+    use modglobal, only : dx,dy,imax,jmax,i1,j1,lambdas,lambdas_x,lambdas_y,lambdas_z,kmax,k1,cexpnr
+    use modthermodynamics, only: lmoist
     use modmpi, only : myidx, myidy
     implicit none
 
@@ -213,7 +214,7 @@ contains
   end subroutine handle_err
 
   subroutine exitsynturb
-    use modglobal, only : lmoist
+    use modthermodynamics, only : lmoist
     implicit none
     integer :: ib
     if(.not.lsynturb) return
@@ -332,7 +333,8 @@ contains
   end subroutine synturb_all
 
   subroutine sepsim()
-    use modglobal, only : rtimee,lmoist
+    use modglobal, only : rtimee
+    use modthermodynamics, only : lmoist
     implicit none
 
     character(len=*), parameter :: routine = modname//'/sepsim'

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -29,9 +29,12 @@
 !
 
 module modthermodynamics
+  use modglobal,    only: checknamelisterror, ifnamopt
+  use modmpi,       only: myid, d_mpi_bcast, commwrld
   use modprecision, only : field_r
   use modtimer
   use modlogging, only: finish
+  use fortran_support, only: nnml_output
   implicit none
   character(len=*), parameter :: modname = 'modthermodynamics'
 !   private
@@ -41,8 +44,15 @@ module modthermodynamics
   public :: esatltab
   public :: esatitab
   public :: esatmtab
+  public :: thermodynamics_read_namelist
 
-  logical :: lqlnr    = .true. !< switch for ql calc. with Newton-Raphson (on/off)
+  logical :: lqlnr = .true.        !< Switch for ql calc. with Newton-Raphson (on/off).
+  logical :: lmoist = .true.       !< Switch to calculate moisture fields.
+  logical :: lnoclouds = .false.   !< Switch to enable/disable thl calculations.
+  logical :: lfast_thermo = .true. !< Switch to enable faster icethermo scheme.
+  logical :: lconstexner = .false. !< Switch to use the initial pressure profile in the exner function.
+  logical :: lbaseexner = .false.  !< Switch to use the base pressure profile in the exner function.
+
   real, allocatable :: th0av(:)
   real(field_r), allocatable :: thv0(:,:,:)
   real :: chi_half=0.5  !< set wet, dry or intermediate (default) mixing over the cloud edge
@@ -56,6 +66,34 @@ module modthermodynamics
   !$acc declare create(ttab, esatltab, esatitab, esatmtab)
 
 contains
+
+  !> Read thermodynamics namelist.
+  subroutine thermodynamics_read_namelist(nml_filename)
+
+    character(len=*), intent(in) :: nml_filename
+
+    integer :: ierr
+
+    namelist /thermodynamics/ lmoist, chi_half, lfast_thermo, lconstexner, &
+      lbaseexner, lqlnr, lnoclouds
+
+    if (myid == 0) then
+      open(ifnamopt, file=nml_filename, status='old', action='read', &
+           iostat=ierr)
+      read(ifnamopt, nml=thermodynamics, iostat=ierr)
+      call checknamelisterror(ierr, ifnamopt, 'thermodynamics')
+      write(nnml_output, thermodynamics)
+      close(ifnamopt)
+    end if
+
+    call d_mpi_bcast(lmoist, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(chi_half, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(lfast_thermo, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(lconstexner, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(lbaseexner, 1, 0, commwrld, ierr)
+    call d_mpi_bcast(lqlnr, 1, 0, commwrld, ierr)
+
+  end subroutine thermodynamics_read_namelist
 
 !> Allocate and initialize arrays
   subroutine initthermodynamics
@@ -102,7 +140,7 @@ contains
 !! Calculate the liquid water content, do the microphysics, calculate the mean hydrostatic pressure,
 !! calculate the fields at the half levels, and finally calculate the virtual potential temperature.
   subroutine thermodynamics
-    use modglobal,  only : lmoist,timee,k1,i1,j1,ih,jh,rd,rv,ijtot,cp,rlv,lnoclouds,lfast_thermo
+    use modglobal,  only : timee,k1,i1,j1,ih,jh,rd,rv,ijtot,cp,rlv
     use modfields,  only : thl0, qt0, ql0, presf, exnf, thvh, thv0h, qt0av, ql0av, thvf, rhof
     use modmpi,     only : slabsum
     use modibm,     only : fluid_mask
@@ -218,7 +256,7 @@ contains
 
 !> Calculate thetav and dthvdz
   subroutine calthv
-    use modglobal, only : lmoist,i1,j1,k1,kmax,zf,dzh,rlv,rd,rv,cp,eps1
+    use modglobal, only : i1,j1,k1,kmax,zf,dzh,rlv,rd,rv,cp,eps1
     use modfields, only : thl0,thl0h,ql0,ql0h,qt0,qt0h,exnf,exnh,thv0h,dthvdz
     use modsurfdata,only : dthldz,dqtdz
     implicit none
@@ -360,7 +398,7 @@ contains
 !!     qt,ql,exner,pressure and the density
 !! \author      Pier Siebesma   K.N.M.I.     06/01/1995
   subroutine diagfld
-  use modglobal,  only : i1,ih,j1,jh,k1,nsv,zh,zf,cu,cv,ijtot,grav,rlv,cp,rd,rv,pref0,timee,lconstexner,lbaseexner
+  use modglobal,  only : i1,ih,j1,jh,k1,nsv,zh,zf,cu,cv,ijtot,grav,rlv,cp,rd,rv,pref0,timee
   use modfields,  only : u0,v0,thl0,qt0,ql0,sv0,u0av,v0av,thl0av,qt0av,ql0av,sv0av, &
                         presf,presh,exnf,exnh,rhof,thvf
   use modsurfdata,only : thls,ps

--- a/src/modtimedep.f90
+++ b/src/modtimedep.f90
@@ -476,7 +476,8 @@ contains
   end subroutine timedepz
 
   subroutine timedepsurf
-    use modglobal,   only : rtimee, lmoist
+    use modglobal,   only : rtimee
+    use modthermodynamics, only: lmoist
     use modsurfdata, only : wtsurf,wqsurf,thls,qts,ps, Qnetav
     use modsurface,  only : qtsurf
     implicit none


### PR DESCRIPTION
Similar to the surface namelist, options for thermodynamics were scattered over different namelists. This PR introduces a new namelist `&thermodynamics` which captures these options centrally.