### PR TITLE
fix unused length of filename

### DIFF
--- a/src/modtracers.f90
+++ b/src/modtracers.f90
@@ -102,7 +102,7 @@ contains
       call warning(routine, trim(file_profs)//' not found')
 #else
       l = len(trim(file_profs))
-      call warning(routine, file_profs//' not found')
+      call warning(routine, file_profs(1:l)//' not found')
 #endif
       nsv_user = 0
     end if


### PR DESCRIPTION
Variable `l` used to compute the length of a filename was not used. This is used with the nvhpc compiler to prevent creating a temporary object with `trim` and work around a compiler bug.