### PR TITLE
Bulkmicro: avoid rain sedimentation when qr ≤ 0

### DIFF
--- a/src/bulkmicro_sb.f90
+++ b/src/bulkmicro_sb.f90
@@ -380,6 +380,12 @@ contains
     real(field_r) :: xr, dvr, mur, lbdr, wfall_qr, sed_qr
 
     !$acc routine seq
+    
+    ! Short-circuit: avoid unphysical sedimentation and derived quantities for qr <= 0
+    if (qr <= 0._field_r) then
+        sed_qr = 0._field_r
+        return
+    end if
 
     xr = calc_xr(rho, qr, nr, xrmin, xrmax)
     dvr = calc_dvr(xr)


### PR DESCRIPTION
### Summary
Add an early return in `calc_sed_qr_sb` to ensure zero rain sedimentation when no rain water is present.

### Details
The sedimentation rate of rain water is proportional to the rain water content (`qr`).  
When `qr ≤ 0`, sedimentation should therefore be zero by definition.

This PR adds a short-circuit at the top of the elemental function to:
- Explicitly return `sed_qr = 0` for `qr ≤ 0`
- Avoid unnecessary and potentially ill-defined calculations of derived rain properties

### Impact
- No change for grid points with rain present
- Improved numerical robustness and clarity for dry conditions
- Safe for elemental, vectorized, and OpenACC execution