### PR TITLE
CMake changes for RRTMGP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,13 +128,13 @@ if( ENABLE_ACC )
   endif()
 endif()
 
+# Set the compiler flags for the selected compiler
+include( dales_compile_options )
+
 # Find the fortran-support library (included).
 include ( dales_add_fortran_support )
 
 # Add RRTMGP
 include( dales_add_rrtmgp )
-
-# Set the compiler flags for the selected compiler
-include( dales_compile_options )
 
 add_subdirectory( src )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,11 +128,11 @@ if( ENABLE_ACC )
   endif()
 endif()
 
-# Set the compiler flags for the selected compiler
-include( dales_compile_options )
-
 # Find the fortran-support library (included).
 include ( dales_add_fortran_support )
+
+# Set the compiler flags for the selected compiler
+include( dales_compile_options )
 
 # Add RRTMGP
 include( dales_add_rrtmgp )

--- a/cmake/dales_add_rrtmgp.cmake
+++ b/cmake/dales_add_rrtmgp.cmake
@@ -2,7 +2,11 @@ include( FetchContent )
 
 set( BUILD_C_HEADERS OFF )
 set( RTE_ENABLE_SP ${ENABLE_FP32_RAD} )
-set( KERNEL_MODE "accel" )
+set( KERNEL_MODE "default" CACHE STRING "Set kernel mode for RTE" )
+
+if( ${ENABLE_ACC} )
+    set( KERNEL_MODE "accel" )
+endif()
 
 ecbuild_info( "Fetching RTE-RRTMGP" )
 


### PR DESCRIPTION
- Fix selection of RRTMGP kernels
- Move definition of compiler flags such that dependencies use the same flags as the main DALES executable