### PR TITLE
modchecksim: fix automatic exit of simulation if lstop=.true.

### DIFF
--- a/src/modchecksim.f90
+++ b/src/modchecksim.f90
@@ -583,6 +583,8 @@ contains
             if (val < threshold(1) .or. val > threshold(2)) then
               call print_warning_out_of_range(name, step, [i, j, k], cval, &
                       [number2string(threshold(1)), number2string(threshold(2))])
+            else
+              cycle
             end if
           else
             cycle
@@ -624,6 +626,8 @@ contains
             if (val < threshold(1) .or. val > threshold(2)) then
               call print_warning_out_of_range(name, step, [i, j, k], cval, &
                       [number2string(threshold(1)), number2string(threshold(2))])
+            else
+              cycle
             end if
           else
             cycle


### PR DESCRIPTION
This fixes a bug that was probably introduced in [https://github.com/dalesteam/dales/commit/4ceba11](https://github.com/dalesteam/dales/commit/4ceba11).
Currently if lstop=true, the simulation crashes immediately. If the value is acceptable, we should cycle, but now the cycle is not hit if a threshold is defined.