### PR TITLE
HYPRE: add hypre initialize function (to fix crash)

### DIFF
--- a/src/modhypre.f90
+++ b/src/modhypre.f90
@@ -54,7 +54,7 @@ save
 ! for fortran
 interface
   subroutine HYPRE_Initialize( ierr) &
-    bind(c, name="hypre_initialize_")
+    bind(c, name="hypre_init_")
     use iso_c_binding
     implicit none
     integer(c_int) ierr

--- a/src/modhypre.f90
+++ b/src/modhypre.f90
@@ -53,6 +53,12 @@ save
 ! We need to append the _ and add bind(c, name) to call the c interface defined
 ! for fortran
 interface
+  subroutine HYPRE_Initialize( ierr) &
+    bind(c, name="hypre_initialize_")
+    use iso_c_binding
+    implicit none
+    integer(c_int) ierr
+  end subroutine
   subroutine HYPRE_StructBiCGSTABCreate ( comm, solver, ierr) &
     bind(c, name="hypre_structbicgstabcreate_")
     use iso_c_binding
@@ -825,6 +831,12 @@ contains
     ! Have hypre reuse the comm world
     mpi_comm_hypre = MPI_COMM_WORLD%MPI_VAL
 
+    !-----------------------------------------------------------------------
+    !     0. Call HYPRE_Initialize().
+    !-----------------------------------------------------------------------
+
+    call HYPRE_Initialize(ierr)
+    
     !-----------------------------------------------------------------------
     !     1. Set up the grid.
     !        Each processor describes the piece of the grid that it owns.

--- a/src/modpois.f90
+++ b/src/modpois.f90
@@ -108,11 +108,12 @@ contains
     else
       ! HYPRE based solver
 
-      ! using FFT based solver as fallback
+      ! by default, DALES does not fallback on FFT based solver when HYPRE doesn't converge. If you do want that:
+      ! (1) uncomment this line, and
       !call fft2dinit(p, Fp, d, xyrt, ps,pe,qs,qe)
 
-      !NOTE: If you don't want to do that, you will need the line below
-      !allocate(p(2-ih:i1+ih,2-jh:j1+jh,kmax))
+      ! 2) comment out this line
+      allocate(p(2-ih:i1+ih,2-jh:j1+jh,kmax))
 
       call inithypre_grid
       call inithypre_solver(psolver,solver_id,maxiter,tolerance,precond_id,n_pre,n_post,maxiter_precond)


### PR DESCRIPTION
Added explicit call to the HYPRE initialize function. Without this (unexpected) crashes may occur.