### PR TITLE
Allow varying LSM albedos

### DIFF
--- a/src/modlsm.f90
+++ b/src/modlsm.f90
@@ -1040,7 +1040,7 @@ end subroutine calc_water_bcs
 subroutine calc_bulk_bcs
     use modglobal,   only : i1, j1, i2, j2, cp, rlv, fkar, zf, cu, cv, grav, rv, rd, lopenbc,lboundary,lperiodic
     use modfields,   only : rhof, thl0, u0, v0, thvh
-    use modsurface,  only : phim, phih
+    use modsurface,  only : phim, phih, albedo
     use modmpi,      only : excjs
     use modopenboundary, only : openboundary_excjs
     use modsurfdata, only : &
@@ -1084,6 +1084,7 @@ subroutine calc_bulk_bcs
             rsveg(i,j) = 0
             rssoil(i,j) = 0
             Qnet(i,j) = 0
+            albedo(i,j) = 0
         enddo
     enddo
 
@@ -1098,6 +1099,7 @@ subroutine calc_bulk_bcs
                     ustar(i,j)  = ustar(i,j) + fraction_slurb(i,j) * slurb_tile%us_urb(i,j)
                     tskin(i,j)  = tskin(i,j) + fraction_slurb(i,j) * slurb_tile%thlskin(i,j)
                     qskin(i,j)  = qskin(i,j) + fraction_slurb(i,j) * slurb_tile%qtskin(i,j)
+                    albedo(i,j) = albedo(i,j) + fraction_slurb(i,j) * slurb_tile%albedo_urb(i,j)
                 else
                     H(i,j)      = H(i,j)     + tile(ilu)%frac(i,j) * tile(ilu)%H(i,j)
                     LE(i,j)     = LE(i,j)    + tile(ilu)%frac(i,j) * tile(ilu)%LE(i,j)
@@ -1106,6 +1108,7 @@ subroutine calc_bulk_bcs
                     tskin(i,j)  = tskin(i,j) + tile(ilu)%frac(i,j) * tile(ilu)%thlskin(i,j)
                     qskin(i,j)  = qskin(i,j) + tile(ilu)%frac(i,j) * tile(ilu)%qtskin(i,j)
                     Qnet(i,j)   = Qnet(i,j)  + tile(ilu)%frac(i,j) * tile(ilu)%Qnet(i,j)
+                    albedo(i,j) = albedo(i,j) + tile(ilu)%frac(i,j) * tile(ilu)%albedo(i,j)
                 endif
            enddo
         enddo
@@ -1736,6 +1739,7 @@ subroutine allocate_on_device()
      !$acc enter data copyin(tile(ilu)%wthl)
      !$acc enter data copyin(tile(ilu)%z0h)
      !$acc enter data copyin(tile(ilu)%z0m)
+     !$acc enter data copyin(tile(ilu)%albedo)
   enddo
 
   !$acc enter data create(rhocp_i, rholv_i)
@@ -1827,6 +1831,7 @@ subroutine deallocate_from_device()
      !$acc exit data delete(tile(ilu)%wthl)
      !$acc exit data delete(tile(ilu)%z0h)
      !$acc exit data delete(tile(ilu)%z0m)
+     !$acc exit data delete(tile(ilu)%albedo)
 
      !$acc exit data delete(tile(ilu))
   enddo
@@ -2059,6 +2064,9 @@ subroutine allocate_tile(tile)
     allocate(tile % wqt(i2, j2))
     allocate(tile % Qnet(i2, j2))
 
+    ! Surface albedo
+    allocate(tile % albedo(i2, j2))
+
     ! Surface temperature and humidity:
     allocate(tile % tskin(i2, j2))
     allocate(tile % thlskin(i2, j2))
@@ -2123,7 +2131,7 @@ subroutine deallocate_tile(tile)
     deallocate( tile%z0m, tile%z0h, tile%base_frac, tile%frac )
     deallocate( tile%obuk, tile%ustar, tile%ra )
     deallocate( tile%lambda_stable, tile%lambda_unstable )
-    deallocate( tile%H, tile%LE, tile%G, tile%wthl, tile%wqt, tile%Qnet)
+    deallocate( tile%H, tile%LE, tile%G, tile%wthl, tile%wqt, tile%Qnet, tile%albedo)
     deallocate( tile%tskin, tile%thlskin, tile%qtskin)
     deallocate( tile%db, tile%lai, tile%rs_min, tile%rs )
     deallocate( tile%a_r, tile%b_r, tile%root_frac, tile%phiw_mean )
@@ -2163,7 +2171,7 @@ end subroutine init_lsm_tiles
 subroutine init_homogeneous
     use modglobal,   only : ifnamopt, fname_options, checknamelisterror, lwarmstart, eps1
     use modmpi,      only : myid, comm3d, mpierr, D_MPI_BCAST
-    use modsurfdata, only : tsoil, tsoilm, phiw, phiwm, wl, wlm, wmax
+    use modsurfdata, only : tsoil, tsoilm, phiw, phiwm, wl, wlm, wmax, albedoav
     use fortran_support, only: nnml_output
     implicit none
 
@@ -2343,6 +2351,13 @@ subroutine init_homogeneous
 
     tile(ilu_aq) % tskin(:,:) = tskin_water
 
+    tile(ilu_lv) % albedo(:,:) = albedoav
+    tile(ilu_hv) % albedo(:,:) = albedoav
+    tile(ilu_bs) % albedo(:,:) = albedoav
+    tile(ilu_ap) % albedo(:,:) = albedoav
+    tile(ilu_aq) % albedo(:,:) = albedoav
+    tile(ilu_ws) % albedo(:,:) = albedoav
+
     if (.not. lwarmstart) then
         ! Init prognostic variables in case of cold start.
         ! For a warm start, these are read from restartfiles
@@ -2403,8 +2418,9 @@ subroutine init_heterogeneous_nc
     use modmpi,      only : myid, myidx, myidy
     use modglobal,   only : imax, jmax, itot, jtot, ldrydep
 
-    use modsurfdata, only : tsoil, tskin, phiw, wl, wlm, wmax
+    use modsurfdata, only : tsoil, tskin, phiw, wl, wlm, wmax, albedoav
     use modlogging, only : profile_output
+    use modstat_nc, only: read_nc_field
     implicit none
     character(len=*), parameter :: routine = modname//'/init_heterogeneous_nc'
 
@@ -2504,6 +2520,7 @@ subroutine init_heterogeneous_nc
     tile(nlu)%LE = 0
     tile(nlu)%G = 0
     tile(nlu)%ustar = 0
+    tile(nlu)%albedo = 0
 
     ! 2D surface fields
     do ilu=1,nlu-1
@@ -2523,6 +2540,7 @@ subroutine init_heterogeneous_nc
       tile(ilu)%LE = 0
       tile(ilu)%G = 0
       tile(ilu)%ustar = 0
+      tile(ilu)%albedo = 0
 
       write(profile_output,*) 'reading variables for LU type: ', trim(tile(ilu)%lushort)
       ! LU cover
@@ -2580,6 +2598,13 @@ subroutine init_heterogeneous_nc
       call check( nf90_get_var(ncid, varid, tile(ilu)%tskin(2:i1, 2:j1) , &
                               start = (/1 + myidx * imax, 1 + myidy * jmax/), &
                               count = (/imax, jmax/) ) )
+      ! albedo
+      ! we read with the new read_nc_field. if requirefill=true and we provide the fillvalue, it will fill any missing values with the fillvalue (instead of throwing an error)
+      call read_nc_field(ncid, 'albedo_'//trim(tile(ilu)%lushort), &
+                              tile(ilu)%albedo(2:i1,2:j1), &
+                              requirefill=.true.,fillvalue=albedoav, &
+                              start = (/1 + myidx * imax, 1 + myidy * jmax/), &
+                              count = (/imax, jmax/) )
 
     !!! deposition parameters
     if (ldrydep) then
@@ -2696,6 +2721,7 @@ subroutine init_heterogeneous_nc
     tile(ilu_ws)%z0h(:,:) = 1e-4
     tile(ilu_ws)%lambda_stable(:,:) = 0
     tile(ilu_ws)%lambda_unstable(:,:) = 0
+    tile(ilu_ws)%albedo = 0
 
     do ilu=1,nlu
         if (tile(ilu)%lushort == "slb") then; cycle; endif
@@ -2706,6 +2732,7 @@ subroutine init_heterogeneous_nc
         tile(ilu_ws)%z0h(:,:) = tile(ilu_ws)%z0h(:,:) + tile(ilu)%base_frac(:,:)*tile(ilu)%z0h(:,:)
         tile(ilu_ws)%lambda_stable(:,:) = tile(ilu_ws)%lambda_stable(:,:) + tile(ilu)%base_frac(:,:)*tile(ilu)%lambda_stable(:,:)
         tile(ilu_ws)%lambda_unstable(:,:) = tile(ilu_ws)%lambda_unstable(:,:) + tile(ilu)%base_frac(:,:)*tile(ilu)%lambda_unstable(:,:)
+        tile(ilu_ws)%albedo = tile(ilu_ws)%albedo + tile(ilu)%base_frac(:,:)*tile(ilu)%albedo(:,:)
       end if
     end do
 
@@ -2807,6 +2834,7 @@ subroutine check_value_validity
         call check_array(tile(ilu)%z0h, 'tile('//tile(ilu)%lushort//')%z0h', routine,[real(0, kind=rkind), real(zf(1),kind=rkind)], stop_if_invalid=.true.)
         call check_array(tile(ilu)%z0m, 'tile('//tile(ilu)%lushort//')%z0m', routine,[real(0, kind=rkind), real(zf(1),kind=rkind)], stop_if_invalid=.true.)
       end if
+      call check_array(tile(ilu)%albedo, 'tile('//tile(ilu)%lushort//')%albedo', routine,[real(0, kind=rkind), real(1,kind=rkind)], stop_if_invalid=.true.)
     end do
     
 end subroutine check_value_validity

--- a/src/modlsmdata.f90
+++ b/src/modlsmdata.f90
@@ -95,6 +95,8 @@ module modlsmdata
       real, allocatable :: phiw_mean(:,:)
       ! Tile net radiation
       real, allocatable :: Qnet(:,:)
+      ! Tile albedo
+      real, allocatable :: albedo(:,:)
 
   ! LU dependent deposition parameters
       ! In-canopy resistance parameters

--- a/src/modopenboundary.f90
+++ b/src/modopenboundary.f90
@@ -302,8 +302,11 @@ contains
     use utils
 
     implicit none
+    character :: routine = modname//'/openboundary_readboundary'
     type(T_tracer), dimension(:), intent(in) :: tracer_prop
     integer :: ib
+    integer :: i_tboundary
+    real :: cur_boundary_time
     character(len = nf90_max_name) :: RecordDimName
     integer :: VARID,STATUS,NCID,timeID,n
     integer, dimension(3) :: istart
@@ -324,6 +327,16 @@ contains
     if (STATUS .ne. nf90_noerr) call handle_err(STATUS)
     STATUS = NF90_GET_VAR (NCID, VARID, tboundary, start=(/1/), count=(/ntboundary/) )
     if (STATUS .ne. nf90_noerr) call handle_err(STATUS)
+
+    !--- check if boundaries are ascending in time...
+    cur_boundary_time = tboundary(1)
+    do i_tboundary = 2, ntboundary
+      if (tboundary(i_tboundary) <= cur_boundary_time) then
+        call finish(routine, 'Boundary times are not in ascending order: ', tboundary(i_tboundary), ' <= ', cur_boundary_time)
+      end if
+      cur_boundary_time = tboundary(i_tboundary)
+    end do
+
     do ib = 1,5 ! loop over boundaries
       ! Allocate input fields
       if(.not.lboundary(ib) .or. lperiodic(ib)) cycle ! Open boundary not present

--- a/src/modraddata.f90
+++ b/src/modraddata.f90
@@ -71,7 +71,7 @@ SAVE
   integer :: iradiation = irad_none      !< Selection parameter for type of radiation scheme
   integer :: irad    = -1                !< Deprecated selection parameter for the type of radiation scheme
   logical :: lCnstZenith = .false.       !< Switch to disable the diurnal cycle and use diurnally averaged SW radiation (e.g. CGILS)
-  logical :: lCnstAlbedo = .true.        !< Switch to disable the surface albedo parameterization in RRTMG
+  logical :: lCnstAlbedo = .true.        !< Switch to disable the surface albedo parameterization in RRTMG. When true, the surface albedo is set from modsurfdata%albedo.
   real :: cnstZenith=0.                  !< constant zenith angle, only used when lCnstZenith=.true. (degrees!)
 
   ! Options in NAMRADIATION that apply to the rrtmg script

--- a/src/modradrrtmg.f90
+++ b/src/modradrrtmg.f90
@@ -219,7 +219,7 @@ contains
         !if(myid==0) write(*,*) 'after call to rrtmg_lw'
       end if
       if (rad_shortw) then
-         call setupSW(sunUp)
+         call setupSW(sunUp,j)
          if (sunUp) then
            call rrtmg_sw & !comments = corresponding variable names in the RRTMGP library
                    (int(imax,kind_im), int(nzrad+1,kind_im), ioverlap, & !ncol, nlay, icld, (+ iaer in later versions !)
@@ -641,7 +641,7 @@ contains
 
       use modglobal, only: imax,jmax,kmax,i1,grav,kind_rb,rlv,cp,Rd,pref0,tup,tdn
       use modfields, only: thl0,ql0,qt0,exnf,rhof
-      use modsurfdata, only: tskin,ps
+      use modsurfdata, only: tskin,ps,albedo
       use modmicrodata, only : Nc_0,sig_g
 
       implicit none
@@ -846,15 +846,17 @@ contains
 ! ==============================================================================;
 ! ==============================================================================;
 
-  subroutine setupSW(sunUp)
+  subroutine setupSW(sunUp,j)
 
-    use modglobal,   only : xday,xlat,xlon,xtime,rtimee
+    use modglobal,   only : xday,xlat,xlon,xtime,rtimee,i1
     use shr_orb_mod, only : shr_orb_decl
-    use modsurfdata, only : albedoav
+    use modsurfdata, only : albedo
 
     implicit none
 
     logical,intent(out) :: sunUp
+    integer,intent(in)  :: j
+    integer             :: i,im
     real                :: dayForSW
 
     if(doperpetual) then
@@ -891,12 +893,15 @@ contains
     if (all(solarZenithAngleCos(:) >= tiny(solarZenithAngleCos))) then
       sunUp = .true.
       if (lCnstAlbedo) then
-        aldir = albedoav
-        asdir = albedoav
-        aldif = albedoav        ! Specification of the diffuse albedo is also important for the
-        asdif = albedoav        ! total surface albedo
+        do i=2,i1
+          im=i-1
+          aldir     (im) = albedo(i,j)
+          asdir     (im) = albedo(i,j)
+          aldif     (im) = albedo(i,j)        ! Specification of the diffuse albedo is also important for the
+          asdif     (im) = albedo(i,j)        ! total surface albedo
+        end do
       else
-        call albedo             ! calculate albedo for the solarZenithAngleCos
+        call calc_albedo_zenith             ! calculate albedo for the solarZenithAngleCos
       end if
 
     end if
@@ -932,7 +937,7 @@ contains
 
 ! ==============================================================================;
 ! ==============================================================================;
-  subroutine albedo
+  subroutine calc_albedo_zenith
     !-----------------------------------------------------------------------
     ! Computes surface albedos over ocean
     ! and the surface (added by Marat Khairoutdinov)
@@ -983,7 +988,7 @@ contains
       end where
     endif
 
-  end subroutine albedo
+  end subroutine calc_albedo_zenith
 
 #endif
 

--- a/src/modradrte_rrtmgp.f90
+++ b/src/modradrte_rrtmgp.f90
@@ -370,7 +370,7 @@ contains
       if(rad_shortw) then
 
         ! setup incoming flux and albedo as a function of the zenith angle
-        call setupSW(sunUp)
+        call setupSW(sunUp, ibatch)
 
         if(sunUp) then
           ! Compute optical properties and incoming shortwave flux
@@ -706,16 +706,23 @@ contains
 
   end subroutine
 
-  subroutine setupSW(sunUp)
+  subroutine setupSW(sunUp, ibatch)
 
-    use modglobal,   only : xday,xlat,xlon,xtime,rtimee
+    use modglobal,   only : xday,xlat,xlon,xtime,rtimee,imax,jmax,i1
     use shr_orb_mod, only : shr_orb_decl
-    use modsurfdata, only : albedoav
+    use modsurfdata, only : albedo
 
     implicit none
 
+    integer, intent(in) :: ibatch
+    integer :: jstart, jend
+    integer :: i, j, icol
     logical,intent(out) :: sunUp
     real                :: dayForSW
+
+    ! Set up j indices to be treated. We need to set the albedo correctly.
+    jstart = (ibatch-1) * jmax/nbatch + 2
+    jend   =  ibatch    * jmax/nbatch + 1
 
     if(doseasons) then
       ! The diurnal cycle of insolation will vary
@@ -736,10 +743,15 @@ contains
       ! Constant albedo for now
       ! Albedos can be computed as a function of solarZenithAngleCos,
       ! so it makes sense to keep the init here
-      !$acc kernels default(present)
-      sfc_alb_dir=albedoav
-      sfc_alb_dif=albedoav
-      !$acc end kernels
+      !$acc parallel loop collapse(2) default(present) private(icol)
+      do j=jstart, jend
+        do i=2,i1 !i1=imax+1
+          icol=i-1+(j-jstart)*imax
+          sfc_alb_dif(:,icol) = albedo(i,j)
+          sfc_alb_dir(:,icol) = albedo(i,j)
+        enddo
+      enddo
+      !
 
     end if
 

--- a/src/modradrte_rrtmgp.f90
+++ b/src/modradrte_rrtmgp.f90
@@ -411,7 +411,9 @@ contains
                                   fluxes_sw)) ! fluxes (inout, W/m2)
           call timer_toc('modradrte_rrtmgp/swrtesolve')
 
-        endif
+        else
+          call zero_SW_for_sunDown()
+        end if
 
       endif
 
@@ -481,7 +483,32 @@ contains
     end if
 
   end subroutine exit_radrte_rrtmgp
+  subroutine zero_SW_for_sunDown
+    implicit none
+    integer :: i, k
 
+    ! Make sure the SW output is 0 if sun is down.
+    ! If the sun is down, rrtmgp does not initialize the sw fluxes arrays, so we need to set them to zero here to avoid uninitialized values in the output.
+    !$acc parallel loop collapse(2) default(present)
+    do i=1,ncol
+      do k=1,nlay+1
+        swUp_slice(i,k) = 0.
+        swDown_slice(i,k) = 0.
+        swDownDir_slice(i,k) = 0.
+      enddo
+    enddo
+
+    if(doclearsky) then
+    !$acc parallel loop collapse(2) default(present)
+     do i=1,ncol
+      do k=1,nlay+1
+          swUpCS_slice(i,k) = 0.
+          swDownCS_slice(i,k) = 0.
+      enddo
+     enddo
+    end if
+
+  end subroutine zero_SW_for_sunDown
   subroutine setupColumnProfiles(ibatch)
 
     use modglobal,   only: imax, jmax, kmax, i1, grav, kind_rb, rlv, cp, rd, pref0, tup, tdn

--- a/src/modslurb/modslurb_radiationmodel.f90
+++ b/src/modslurb/modslurb_radiationmodel.f90
@@ -27,8 +27,9 @@ module modslurb_radiationmodel
     use modslurbdata
     real(field_r) ::  azimuth        !< solar azimuth angle
     real(field_r) ::  tan_zenith     !< tangent of the solar zenith angle
-    real ::  zenith         !< solar zenith angle
-    real :: sun_dir_lon, sun_dir_lat, cos_zenith
+    real ::  cos_zenith              !< cosine of solar zenith angle
+    real ::  zenith                  !< solar zenith angle
+    real :: sun_dir_lon, sun_dir_lat
     contains
 
  !--------------------------------------------------------------------------------------------------!
@@ -51,11 +52,9 @@ module modslurb_radiationmodel
       !
       !-- Compute the solar zenith and azimuth angles for the current time and location. These are needed
       !-- for the shortwave radiation calculations
-    call zenith_lon_lat(xtime*3600_field_r + rtimee, xday, xlat, xlon, zenith, sun_dir_lon, sun_dir_lat)
+    call zenith_lon_lat(xtime*3600_field_r + rtimee, xday, xlat, xlon, cos_zenith, sun_dir_lon, sun_dir_lat)
     azimuth = ATAN2( sun_dir_lon, sun_dir_lat )
-    cos_zenith = COS(zenith)
-
-
+    zenith = ACOS( cos_zenith )
     !
     !-- Split the incoming SW radiation into direct and diffuse parts.
     !-- Direct-diffuse SW split is quite weirdly done in the radiation mod if radiation
@@ -193,7 +192,7 @@ module modslurb_radiationmodel
 
     !
     !-- Check if there is any shortwave radiation to take care of in the first place.
-    IF ( .NOT. ( cos_zenith > 0.0_field_r ) )  THEN
+    IF ( .NOT. ( cos_zenith > tiny(cos_zenith) ) )  THEN
        slurb_tile%rad_sw_in_urb(i,j)     = 0.0_field_r
        slurb_tile%rad_sw_net_urb(i,j)    = 0.0_field_r
        slurb_tile%rad_sw_net_roof(i,j)   = 0.0_field_r

--- a/src/modstat_nc.f90
+++ b/src/modstat_nc.f90
@@ -30,6 +30,7 @@
 module modstat_nc
     use netcdf
     use modprecision, only: field_r
+    use, intrinsic :: iso_fortran_env, only: real64, real32
     use modmpi,       only: myid
     use modlogging, only: finish
     implicit none
@@ -54,11 +55,14 @@ module modstat_nc
 
     !> Read a field from a netCDF file by its name
     interface read_nc_field
-        module procedure read_nc_field_1D_real
+        module procedure read_nc_field_1D_real4
+        module procedure read_nc_field_1D_real8
         module procedure read_nc_field_1D_int
-        module procedure read_nc_field_2D_real
+        module procedure read_nc_field_2D_real4
+        module procedure read_nc_field_2D_real8
         module procedure read_nc_field_2D_int
-        module procedure read_nc_field_3D_real
+        module procedure read_nc_field_3D_real4
+        module procedure read_nc_field_3D_real8
         module procedure read_nc_field_3D_int
     end interface read_nc_field
 
@@ -69,11 +73,14 @@ module modstat_nc
       module procedure read_nc_attribute_logical
     end interface read_nc_attribute
 
-    private :: read_nc_field_1D_real
+    private :: read_nc_field_1D_real4
+    private :: read_nc_field_1D_real8
     private :: read_nc_field_1D_int
-    private :: read_nc_field_2D_real
+    private :: read_nc_field_2D_real4
+    private :: read_nc_field_2D_real8
     private :: read_nc_field_2D_int
-    private :: read_nc_field_3D_real
+    private :: read_nc_field_3D_real4
+    private :: read_nc_field_3D_real8
     private :: read_nc_field_3D_int
 
     private :: read_nc_attribute_char
@@ -651,13 +658,13 @@ contains
   !! is not found.
   !! @param requirefill Set to false to allow the array to left unfilled if the variable is missing.
   !! Use for arrays that are pre-initialized, which you want to replace with some user input.
-  subroutine read_nc_field_1D_real(ncid, varname, array, start, count, fillvalue, requirefill)
+  subroutine read_nc_field_1D_real4(ncid, varname, array, start, count, fillvalue, requirefill)
     integer,       intent(in)           :: ncid
     character(*),  intent(in)           :: varname
-    real(field_r), intent(inout)        :: array(:)
+    real(real32), intent(inout)        :: array(:)
     integer,       intent(in), optional :: start
     integer,       intent(in), optional :: count
-    real(field_r), intent(in), optional :: fillvalue
+    real(real32), intent(in), optional :: fillvalue
     logical,       intent(in), optional :: requirefill
 
     integer :: varid
@@ -698,8 +705,66 @@ contains
         call nchandle_error(ierr)
     end select
 
-  end subroutine read_nc_field_1D_real
+  end subroutine read_nc_field_1D_real4
+  !> Read a 1D real field from a netCDF by its name.
+  !!
+  !! Optionally, a fill value can be provided, which the is used in case the
+  !! requested variable is not found in the netCDF file.
+  !! @param ncid ID of the opened netCDF file.
+  !! @param varname Name of the variable to read.
+  !! @param array Array to fill.
+  !! @param fillvalue Default value to fill array with in case the variable
+  !! is not found.
+  !! @param requirefill Set to false to allow the array to left unfilled if the variable is missing.
+  !! Use for arrays that are pre-initialized, which you want to replace with some user input.
+  subroutine read_nc_field_1D_real8(ncid, varname, array, start, count, fillvalue, requirefill)
+    integer,       intent(in)           :: ncid
+    character(*),  intent(in)           :: varname
+    real(real64), intent(inout)        :: array(:)
+    integer,       intent(in), optional :: start
+    integer,       intent(in), optional :: count
+    real(real64), intent(in), optional :: fillvalue
+    logical,       intent(in), optional :: requirefill
 
+    integer :: varid
+    integer :: ierr
+    integer :: start_(1), count_(1)
+    logical :: requirefill_ = .true. !< default value which is actually used in the code, if requirefill is present, override this value.
+
+    if (present(requirefill)) requirefill_ = requirefill
+
+    ierr = nf90_inq_varid(ncid, varname, varid)
+
+    if (present(start)) then 
+      start_(1) = start
+    else
+      start_(1) = 1
+    end if
+
+    if (present(count)) then
+      count_(1) = count
+    else
+      count_(1) = size(array)
+    end if
+
+    select case (ierr)
+      case (NF90_ENOTVAR)
+        if (requirefill_) then
+          if (present(fillvalue)) then
+            array(:) = fillvalue
+          else
+            call nchandle_error(ierr)
+          end if
+        else
+          return
+        endif
+      case (NF90_NOERR)
+        call nchandle_error(nf90_get_var(ncid, varid, array, start=start_, count=count_))
+      case default
+        call nchandle_error(ierr)
+    end select
+
+  end subroutine read_nc_field_1D_real8
   !> Read a 2D real field from a netCDF by its name.
   !!
   !! Optionally, a fill value can be provided, which the is used in case the
@@ -711,13 +776,13 @@ contains
   !! is not found.
   !! @param requirefill Set to false to allow the array to left unfilled if the variable is missing.
   !! Use for arrays that are pre-initialized, which you want to replace with some user input.
-  subroutine read_nc_field_2D_real(ncid, varname, array, start, count, fillvalue, requirefill)
+  subroutine read_nc_field_2D_real4(ncid, varname, array, start, count, fillvalue, requirefill)
     integer,       intent(in)           :: ncid
     character(*),  intent(in)           :: varname
-    real(field_r), intent(inout)        :: array(:,:)
+    real(real32), intent(inout)        :: array(:,:)
     integer,       intent(in), optional :: start(2)
     integer,       intent(in), optional :: count(2)
-    real(field_r), intent(in), optional :: fillvalue
+    real(real32), intent(in), optional :: fillvalue
     logical,       intent(in), optional :: requirefill
 
     integer :: varid
@@ -758,8 +823,66 @@ contains
         call nchandle_error(ierr)
     end select
 
-  end subroutine read_nc_field_2D_real
+  end subroutine read_nc_field_2D_real4
+  !> Read a 2D real field from a netCDF by its name.
+  !!
+  !! Optionally, a fill value can be provided, which the is used in case the
+  !! requested variable is not found in the netCDF file.
+  !! @param ncid ID of the opened netCDF file.
+  !! @param varname Name of the variable to read.
+  !! @param array Array to fill.
+  !! @param fillvalue Default value to fill array with in case the variable
+  !! is not found.
+  !! @param requirefill Set to false to allow the array to left unfilled if the variable is missing.
+  !! Use for arrays that are pre-initialized, which you want to replace with some user input.
+  subroutine read_nc_field_2D_real8(ncid, varname, array, start, count, fillvalue, requirefill)
+    integer,       intent(in)           :: ncid
+    character(*),  intent(in)           :: varname
+    real(real64), intent(inout)        :: array(:,:)
+    integer,       intent(in), optional :: start(2)
+    integer,       intent(in), optional :: count(2)
+    real(real64), intent(in), optional :: fillvalue
+    logical,       intent(in), optional :: requirefill
 
+    integer :: varid
+    integer :: ierr
+    integer :: start_(2), count_(2)
+    logical :: requirefill_ = .true. !< default value which is actually used in the code, if requirefill is present, override this value.
+
+    if (present(requirefill)) requirefill_ = requirefill
+
+    ierr = nf90_inq_varid(ncid, varname, varid)
+
+    if (present(start)) then 
+      start_(:) = start(:)
+    else
+      start_(:) = 1
+    end if
+
+    if (present(count)) then
+      count_(:) = count(:)
+    else
+      count_(:) = shape(array)
+    end if
+
+    select case (ierr)
+      case (NF90_ENOTVAR)
+        if (requirefill_) then
+          if (present(fillvalue)) then
+            array(:,:) = fillvalue
+          else
+            call nchandle_error(ierr)
+          end if
+        else
+          return
+        endif
+      case (NF90_NOERR)
+        call nchandle_error(nf90_get_var(ncid, varid, array, start=start_, count=count_))
+      case default
+        call nchandle_error(ierr)
+    end select
+
+  end subroutine read_nc_field_2D_real8
 
   !> Read a 2D integer field from a netCDF by its name.
   !!
@@ -832,13 +955,13 @@ contains
   !! is not found.
   !! @param requirefill Set to false to allow the array to left unfilled if the variable is missing.
   !! Use for arrays that are pre-initialized, which you want to replace with some user input.
-  subroutine read_nc_field_3D_real(ncid, varname, array, start, count, fillvalue, requirefill)
+  subroutine read_nc_field_3D_real4(ncid, varname, array, start, count, fillvalue, requirefill)
     integer,       intent(in)           :: ncid
     character(*),  intent(in)           :: varname
-    real(field_r), intent(inout)        :: array(:,:,:)
+    real(real32), intent(inout)        :: array(:,:,:)
     integer,       intent(in), optional :: start(3)
     integer,       intent(in), optional :: count(3)
-    real(field_r), intent(in), optional :: fillvalue
+    real(real32), intent(in), optional :: fillvalue
     logical,       intent(in), optional :: requirefill
 
     integer :: varid
@@ -879,8 +1002,67 @@ contains
         call nchandle_error(ierr)
     end select
 
-  end subroutine read_nc_field_3D_real
+  end subroutine read_nc_field_3D_real4
 
+  !> Read a 3D real field from a netCDF by its name.
+  !!
+  !! Optionally, a fill value can be provided, which the is used in case the
+  !! requested variable is not found in the netCDF file.
+  !! @param ncid ID of the opened netCDF file.
+  !! @param varname Name of the variable to read.
+  !! @param array Array to fill.
+  !! @param fillvalue Default value to fill array with in case the variable
+  !! is not found.
+  !! @param requirefill Set to false to allow the array to left unfilled if the variable is missing.
+  !! Use for arrays that are pre-initialized, which you want to replace with some user input.
+  subroutine read_nc_field_3D_real8(ncid, varname, array, start, count, fillvalue, requirefill)
+    integer,       intent(in)           :: ncid
+    character(*),  intent(in)           :: varname
+    real(real64), intent(inout)        :: array(:,:,:)
+    integer,       intent(in), optional :: start(3)
+    integer,       intent(in), optional :: count(3)
+    real(real64), intent(in), optional :: fillvalue
+    logical,       intent(in), optional :: requirefill
+
+    integer :: varid
+    integer :: ierr
+    integer :: start_(3), count_(3)
+    logical :: requirefill_ = .true. !< default value which is actually used in the code, if requirefill is present, override this value.
+
+    if (present(requirefill)) requirefill_ = requirefill
+
+    ierr = nf90_inq_varid(ncid, varname, varid)
+
+    if (present(start)) then 
+      start_(:) = start(:)
+    else
+      start_(:) = 1
+    end if
+
+    if (present(count)) then
+      count_(:) = count(:)
+    else
+      count_(:) = shape(array)
+    end if
+
+    select case (ierr)
+      case (NF90_ENOTVAR)
+        if (requirefill_) then
+          if (present(fillvalue)) then
+            array(:,:,:) = fillvalue
+          else
+            call nchandle_error(ierr)
+          end if
+        else
+          return
+        endif
+      case (NF90_NOERR)
+        call nchandle_error(nf90_get_var(ncid, varid, array, start=start_, count=count_))
+      case default
+        call nchandle_error(ierr)
+    end select
+
+  end subroutine read_nc_field_3D_real8
 
   !> Read a 3D integer field from a netCDF by its name.
   !!


### PR DESCRIPTION
Allows LSM tiles to have varying albedos.
Also adds a helpful crash to openboundary when the input boundaries are not sorted in time. Otherwise, you get some pretty weird undetermined behavior...