### PR TITLE
thermodynamics: zero ql when a layer is below saturation

### DIFF
--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -787,6 +787,8 @@ contains
             ql(i,j,k) = max(qt(i,j,k) - qsat, 0.0_field_r)
           end do
         end do
+      else
+        ql(:,:,k) = 0
       end if
     end do
 

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -316,8 +316,6 @@ contains
 
     call timer_tic(routine, 1)
 
-    dthvdz = 0
-
     if (lmoist) then
       !$acc parallel loop collapse(3) default(present) async(1)
       do k = 2, k1


### PR DESCRIPTION
fixes an issue where LWP shows random cloudy pixels which stay in place. In multi-core runs they would show up at domain boundaries.

