### PR TITLE
Fix various issues

### DIFF
--- a/src/modlsm.f90
+++ b/src/modlsm.f90
@@ -2702,6 +2702,13 @@ subroutine init_heterogeneous_nc
       end if
     end do
 
+    ! we fill the temperature and moisture fields with 0.
+    ! we later write these including halo cells in writerestartfiles
+    ! which is a write with uninitialized values which can sometimes cause
+    ! a crash. so we initialize to 0 here to avoid that.
+    tsoil(:,:,:) = 0
+    phiw(:,:,:) = 0
+
     ! 3D soil fields
     ! soil index
     call check( nf90_inq_varid( ncid, 'index_soil', varid) )

--- a/src/modradrrtmg.f90
+++ b/src/modradrrtmg.f90
@@ -651,7 +651,7 @@ contains
                                            cloudFrac(imax,krad1), &
                                            liquidRe (imax,krad1), &
                                            iceRe    (imax,krad1), &
-                                           emis     (imax,krad1)
+                                           emis     (imax,16)
       integer :: i,k,ksounding,im
       real(KIND=kind_rb) :: exners
       real(KIND=kind_rb) :: layerMass(imax,krad1)
@@ -692,12 +692,11 @@ contains
 
         !tg_slice  (im)   = sst
         tg_slice  (im)   = tskin(i,j) * exners  ! Note: tskin = thlskin...
-
+        ! Surface emissivity for all bands set from modsurface.
+        ! Currently this is calculated every radiation call, want to move this to initradiation ideally,
+        ! but we need to allow modslurb to initialize to get the emissivity...
+        emis      (im,:) = emissivity(i,j)
         do k=1,kmax
-          ! Surface emissivity for all bands set from modsurface.
-          ! Currently this is calculated every radiation call, want to move this to initradiation ideally,
-          ! but we need to allow modslurb to initialize to get the emissivity...
-           emis      (im,k) = emissivity(i,j)
 
            qv_slice  (im,k) = max(qt0(i,j,k) - ql0(i,j,k),1e-18_field_r) !avoid RRTMG reading negative initial values
 

--- a/src/modslurb/modslurb.f90
+++ b/src/modslurb/modslurb.f90
@@ -347,6 +347,7 @@ end subroutine slurb_update_external_vars
     integer, parameter :: rkind = kind( 1.0_field_r )
     INTEGER, DIMENSION(:,:), ALLOCATABLE ::  type_tmp  !< array to contain building type temporarily
     integer i,j,k, ncid
+    character(len=100) :: errstr
     
     if (lread_from_netcdf) then
         call nchandle_error(nf90_open('inslurb.'//cexpnr//'.nc', NF90_NOWRITE, ncid))
@@ -367,6 +368,10 @@ end subroutine slurb_update_external_vars
     call check_array(slurb_tile%f_bld(2:i1,2:j1), "f_bld", routine, threshold=[real( TINY( 1.0_field_r ),rkind),real(  1.0_field_r ,rkind)], stop_if_invalid=.true.)
     do j=2,j1
       do i=2,i1
+        if ( slurb_tile%f_bld(i,j) > fraction_slurb(i, j) ) then
+            write(errstr,*), "Building fraction f_bld(",i,",",j,")=",slurb_tile%f_bld(i,j)," cannot be larger than the urban surface fraction=", fraction_slurb(i, j), ". Check your input file. f_bld represents the building plan area fraction of the total surface."
+            call finish(routine, errstr)
+        endif
         if ( fraction_slurb(i,j) /= 0) then
             slurb_tile%f_bld(i, j) = slurb_tile%f_bld(i, j) / fraction_slurb(i, j)
         endif

--- a/src/modslurb/modslurb.f90
+++ b/src/modslurb/modslurb.f90
@@ -204,10 +204,9 @@ subroutine initslurb
     if (.not. enable_slurb) then
         return
     end if
-    call warning(routine, "SLUrb module enabled. Keep in mind that calculation of effective albedo is not implemented yet!")
     call warning(routine, "SLUrb module enabled. Keep in mind that different building drag parametrizations have not been tested yet!")
     call warning(routine, "SLUrb module enabled. Keep in mind that moist_physics=false has not been tested yet!")
-    call warning(routine, "SLUrb module enabled. Only rrtmgp radiation has been tested with SLUrb!")
+    call warning(routine, "SLUrb module enabled. Only rrtmgp or rte-rrtmgp radiation has been tested with SLUrb!")
 
     call check_array([deep_soil_temperature],"deep_soil_temperature", routine, &
     threshold=[real(100.0_field_r,rkind),real( 400.0_field_r,rkind)], &

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -1949,6 +1949,7 @@ contains
 
   !> Check prognostic variables before simulation
   subroutine check_initial_state()
+    use modglobal, only: lopenbc, i1, j1, kmax
     use modthermodynamics, only: lmoist
     use modfields, only: u0, v0, w0, thl0, qt0, sv0
     use modchecksim, only: lstop
@@ -1965,8 +1966,13 @@ contains
                      threshold=[real(-100, rkind), real(100, rkind)],stop_if_invalid=lstop, dump_if_invalid=.true.)
     call check_array(w0, 'w0', 'startup', &
                      threshold=[real(-30, rkind), real(30, rkind)],stop_if_invalid=lstop, dump_if_invalid=.true.)
-    call check_array(thl0, 'thl0', 'startup', &
-                     threshold=[real(150, rkind), real(2000, rkind)],stop_if_invalid=lstop, dump_if_invalid=.true.)
+    if (lopenbc) then
+      call check_array(thl0(2:i1,2:j1,1:kmax), 'thl0', 'startup', &
+                      threshold=[real(150, rkind), real(2000, rkind)],stop_if_invalid=lstop, dump_if_invalid=.true.)
+    else
+      call check_array(thl0, 'thl0', 'startup', &
+                      threshold=[real(150, rkind), real(2000, rkind)],stop_if_invalid=lstop, dump_if_invalid=.true.)
+    end if
     if (lmoist) call check_array(qt0, 'qt0', 'startup', &
                                  threshold=[real(0, rkind), real(1, rkind)],stop_if_invalid=lstop, dump_if_invalid=.true.)
 


### PR DESCRIPTION
This PR fixes the spam of thl0 check_array warnings when using openBC, fixes quite a big bug in the varying-emis implementation in rrtmg, a very small bug where tsoil,phiw were not fully initialized, but putting them in the restartfile at the end is actually an uninitialized read which caused some weird crashes for me.
Some extra slurb stuff: remove reduntant warning, add extra warning if input is messy.