### PR TITLE
Rotated domains (Coriolis)

### DIFF
--- a/src/addon/modstress.f90
+++ b/src/addon/modstress.f90
@@ -187,7 +187,7 @@ contains
   subroutine do_stressbudget
     use modglobal,  only : i1,i2,j1,j2,k1,ih,jh,imax,jmax,kmax,dzf,dzh, &
                           ijtot,cu,cv,iadv_thl,grav, &
-                          dxi,dyi,dx2i,dy2i,om22,om23,iadv_cd2,iadv_5th,iadv_cd6,iadv_mom
+                          dxi,dyi,dx2i,dy2i,om22,om23,iadv_cd2,iadv_5th,iadv_cd6,iadv_mom,corot,sirot
     use modsurfdata, only : thvs, ustar
     use modsubgrid, only : ekm, diffu, diffv, diffw
     use modpois,    only : p
@@ -775,15 +775,18 @@ contains
 
     u_term(2:i1,2:j1,1:kmax) =   &
             +(v0_dev(2:i1,2:j1,1:kmax)+v0_dev(2:i1,3:j2,1:kmax)+v0_dev(1:imax,2:j1,1:kmax)+v0_dev(1:imax,3:j2,1:kmax))*om23*0.25 &
-            -(w0_dev(2:i1,2:j1,1:kmax)+w0_dev(2:i1,2:j1,2:k1)+w0_dev(1:imax,2:j1,2:k1)+w0_dev(1:imax,2:j1,1:kmax))*om22*0.25
+            -(w0_dev(2:i1,2:j1,1:kmax)+w0_dev(2:i1,2:j1,2:k1)+w0_dev(1:imax,2:j1,2:k1)+w0_dev(1:imax,2:j1,1:kmax))*om22*0.25*corot
 
-    v_term(2:i1,2:j1,:) =  &
+    v_term(2:i1,2:j1,1:kmax) =  &
+            +(w0_dev(2:i1,2:j1,1:kmax)+w0_dev(2:i1,2:j1,2:k1)+w0_dev(2:i1,1:jmax,2:k1)+w0_dev(2:i1,1:jmax,1:kmax))*om22*0.25*sirot
             -(u0_dev(2:i1,2:j1,:)+u0_dev(2:i1,1:j1-1,:)+u0_dev(3:i2,1:j1-1,:)+u0_dev(3:i2,2:j1,:))*om23*0.25
 
     do k=2,k1
        w_term(2:i1,2:j1,k) =   &
-                    om22 * 0.25*( (dzf(k-1) * (u0_dev(2:i1,2:j1,k-1)  + u0_dev(3:i2,2:j1,k-1) )     &
-                                 + dzf(k)  *  (u0_dev(2:i1,2:j1,k) + u0_dev(3:i2,2:j1,k))  ) / dzh(k) )
+               + om22 * 0.25 * corot * ( (dzf(k-1) * (u0_dev(2:i1,2:j1,k-1)  + u0_dev(3:i2,2:j1,k-1) )     &
+                        + dzf(k)  *  (u0_dev(2:i1,2:j1,k) + u0_dev(3:i2,2:j1,k))  ) / dzh(k) )
+               - om22 * 0.25 * sirot * ( (dzf(k-1) * (v0_dev(2:i1,2:j1,k-1)  + v0_dev(2:i1,3:j2,k-1) )     &
+                        + dzf(k)  *  (v0_dev(2:i1,2:j1,k) + v0_dev(2:i1,3:j2,k))  ) / dzh(k) )
     enddo
 
     w_term(:,:,1) = 0.

--- a/src/modforces.f90
+++ b/src/modforces.f90
@@ -158,7 +158,7 @@ contains
 !                                                                 |
 !-----------------------------------------------------------------|
 
-  use modglobal, only : i1,j1,kmax,dzh,dzf,cu,cv,om22,om23,lcoriol,lopenbc,lboundary,lperiodic
+  use modglobal, only : i1,j1,kmax,dzh,dzf,cu,cv,om22,om23,lcoriol,lopenbc,lboundary,lperiodic,corot,sirot
   use modfields, only : u0,v0,w0,up,vp,wp
   implicit none
 
@@ -179,9 +179,9 @@ contains
     do k = 1, kmax
       do j = 2, j1
         do i = sx, i1
-          up(i,j,k) = up(i,j,k)+ cv*om23 &
+          up(i,j,k) = up(i,j,k) + cv*om23 &
                 +(v0(i,j,k)+v0(i,j+1,k)+v0(i-1,j,k)+v0(i-1,j+1,k))*om23*0.25_field_r &
-                -(w0(i,j,k)+w0(i,j,k+1)+w0(i-1,j,k+1)+w0(i-1,j,k))*om22*0.25_field_r
+                -(w0(i,j,k)+w0(i,j,k+1)+w0(i-1,j,k+1)+w0(i-1,j,k))*om22*0.25_field_r*corot
         end do
       end do
     end do
@@ -190,8 +190,9 @@ contains
     do k = 1, kmax
       do j = sy, j1
         do i = 2, i1
-          vp(i,j,k) = vp(i,j,k)  - cu*om23 &
-                -(u0(i,j,k)+u0(i,j-1,k)+u0(i+1,j-1,k)+u0(i+1,j,k))*om23*0.25_field_r
+          vp(i,j,k) = vp(i,j,k) - cu*om23 &
+                -(u0(i,j,k)+u0(i,j-1,k)+u0(i+1,j-1,k)+u0(i+1,j,k))*om23*0.25_field_r &
+                +(w0(i,j,k)+w0(i,j-1,k)+w0(i,j,k+1)+w0(i,j-1,k+1))*om22*0.25_field_r*sirot
         end do
       end do
     end do
@@ -200,9 +201,11 @@ contains
     do k = 2, kmax
       do j = 2, j1
         do i = 2, i1
-          wp(i,j,k) = wp(i,j,k) + cu*om22 +( (dzf(k-1) * (u0(i,j,k)  + u0(i+1,j,k) )    &
+          wp(i,j,k) = wp(i,j,k) + cu*om22*corot + ( (dzf(k-1) * (u0(i,j,k)  + u0(i+1,j,k) )    &
                       +    dzf(k)  * (u0(i,j,k-1) + u0(i+1,j,k-1))  ) / dzh(k) ) &
-                      * om22*0.25_field_r
+                      * om22*0.25_field_r*corot &
+                      - ( (dzf(k-1) * (v0(i,j,k)  + v0(i,j+1,k) ) + dzf(k) * (v0(i,j,k-1) + v0(i,j+1,k-1)) ) / dzh(k) ) &
+                      * om22*0.25_field_r*sirot
         end do
       end do
     end do
@@ -225,14 +228,17 @@ contains
         do i = 2, i1
           up(i,j,k) = up(i,j,k)+ cv*om23 &
                 +(v0(i,j,k)+v0(i,j+1,k)+v0(i-1,j,k)+v0(i-1,j+1,k))*om23*0.25_field_r &
-                -(w0(i,j,k)+w0(i,j,k+1)+w0(i-1,j,k+1)+w0(i-1,j,k))*om22*0.25_field_r
+                -(w0(i,j,k)+w0(i,j,k+1)+w0(i-1,j,k+1)+w0(i-1,j,k))*om22*0.25_field_r*corot
 
           vp(i,j,k) = vp(i,j,k)  - cu*om23 &
-                -(u0(i,j,k)+u0(i,j-1,k)+u0(i+1,j-1,k)+u0(i+1,j,k))*om23*0.25_field_r
+                -(u0(i,j,k)+u0(i,j-1,k)+u0(i+1,j-1,k)+u0(i+1,j,k))*om23*0.25_field_r &
+                +(w0(i,j,k)+w0(i,j-1,k)+w0(i,j,k+1)+w0(i,j-1,k+1))*om22*0.25_field_r*sirot
 
-          wp(i,j,k) = wp(i,j,k) + cu*om22 +( (dzf(k-1) * (u0(i,j,k)  + u0(i+1,j,k) )    &
+          wp(i,j,k) = wp(i,j,k) + cu*om22*corot +( (dzf(k-1) * (u0(i,j,k)  + u0(i+1,j,k) )    &
                       +    dzf(k)  * (u0(i,j,k-1) + u0(i+1,j,k-1))  ) / dzh(k) ) &
-                      * om22*0.25_field_r
+                      * om22*0.25_field_r*corot &
+                      - ( (dzf(k-1) * (v0(i,j,k)  + v0(i,j+1,k) ) + dzf(k) * (v0(i,j,k-1) + v0(i,j+1,k-1)) ) / dzh(k) ) &
+                      * om22*0.25_field_r*sirot
         end do
       end do
     end do
@@ -245,10 +251,11 @@ contains
       do i = 2, i1
         up(i,j,1) = up(i,j,1)  + cv*om23 &
               +(v0(i,j,1)+v0(i,j+1,1)+v0(i-1,j,1)+v0(i-1,j+1,1))*om23*0.25_field_r &
-              -(w0(i,j,1)+w0(i,j ,2)+w0(i-1,j,2)+w0(i-1,j ,1))*om22*0.25_field_r
+              -(w0(i,j,1)+w0(i,j ,2)+w0(i-1,j,2)+w0(i-1,j ,1))*om22*0.25_field_r*corot
 
         vp(i,j,1) = vp(i,j,1) - cu*om23 &
-              -(u0(i,j,1)+u0(i,j-1,1)+u0(i+1,j-1,1)+u0(i+1,j,1))*om23*0.25_field_r
+              -(u0(i,j,1)+u0(i,j-1,1)+u0(i+1,j-1,1)+u0(i+1,j,1))*om23*0.25_field_r &
+              +(w0(i,j,1)+w0(i,j-1,1)+w0(i  ,j  ,2)+w0(i,j-1,2))*om22*0.25_field_r*sirot
 
         wp(i,j,1) = 0.0
       end do

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -110,6 +110,7 @@ save
       real,parameter :: gamma_T_matrix = 3.4293695508945325 !< Heat conductivity soil [J s-1 m-1 K-1]
       real,parameter :: gamma_T_water  = 0.57       !< Heat conductivity water [J s-1 m-1 K-1]
 
+      ! Physics / forcings
       logical       :: lcoriol  = .true.  !<  switch for coriolis force
       logical       :: lpressgrad = .false.  !<  switch for horizontal pressure gradient (not to be used in combination with coriolis force)
       integer       :: igrw_damp = 2 !< switch to enable gravity wave damping
@@ -121,6 +122,9 @@ save
       real(field_r) :: om23_gs                       !<    *2.*omega_earth*sin(lat)
       real          :: xlat    = 52.              !<    *latitude  in degrees.
       real          :: xlon    = 0.               !<    *longitude in degrees.
+      real          :: beta    = 0.               !< Rotation angle of local xy plane with respect to Easting vector (postive turning towards Northing vector) in degrees
+      real(field_r) :: corot                      !< cos(beta*pi/180)
+      real(field_r) :: sirot                      !< sin(beta*pi/180)
       logical       :: lrigidlid = .false. !< switch to enable simulations with a rigid lid
       real(field_r) :: unudge = 1.0   !< Nudging factor if igrw_damp == -1 (nudging mean wind fields to geostrophic values provided by lscale.inp)
 
@@ -258,7 +262,7 @@ contains
     character(len=*), parameter :: routine = modname//'/initglobal'
 
     integer :: advarr(4)
-    real phi, colat, silat, omega, omega_gs
+    real phi, colat, silat, omega, omega_gs, gamma
     real :: ilratio
     integer :: k, m, ierr
     integer :: ncid, height_id
@@ -331,6 +335,10 @@ contains
     phi    = xlat*pi/180.
     colat  = cos(phi)
     silat  = sin(phi)
+
+    gamma = beta*pi/180. 
+    corot = cos(gamma) 
+    sirot = sin(gamma) 
 
     omega = 7.292e-5
     omega_gs = 7.292e-5

--- a/src/modglobal.f90
+++ b/src/modglobal.f90
@@ -122,9 +122,9 @@ save
       real(field_r) :: om23_gs                       !<    *2.*omega_earth*sin(lat)
       real          :: xlat    = 52.              !<    *latitude  in degrees.
       real          :: xlon    = 0.               !<    *longitude in degrees.
-      real          :: beta    = 0.               !< Rotation angle of local xy plane with respect to Easting vector (postive turning towards Northing vector) in degrees
-      real(field_r) :: corot                      !< cos(beta*pi/180)
-      real(field_r) :: sirot                      !< sin(beta*pi/180)
+      real          :: xyrot   = 0.               !< Rotation angle of local xy plane with respect to Easting vector (postive turning towards Northing vector) in degrees
+      real(field_r) :: corot                      !< cos(xyrot*pi/180)
+      real(field_r) :: sirot                      !< sin(xyrot*pi/180)
       logical       :: lrigidlid = .false. !< switch to enable simulations with a rigid lid
       real(field_r) :: unudge = 1.0   !< Nudging factor if igrw_damp == -1 (nudging mean wind fields to geostrophic values provided by lscale.inp)
 
@@ -336,7 +336,7 @@ contains
     colat  = cos(phi)
     silat  = sin(phi)
 
-    gamma = beta*pi/180. 
+    gamma = xyrot*pi/180. 
     corot = cos(gamma) 
     sirot = sin(gamma) 
 

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -72,7 +72,7 @@ contains
 
     use modglobal,         only : version,initglobal,iexpnr, ltotruntime, runtime, dtmax, dtav_glob,timeav_glob,&
                                   lwarmstart,startfile,trestart,&
-                                  nsv,itot,jtot,kmax,xsize,ysize,xlat,xlon,xyear,xday,xtime,beta,&
+                                  nsv,itot,jtot,kmax,xsize,ysize,xlat,xlon,xyear,xday,xtime,xyrot,&
                                   lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,cu,cv,&
                                   ifnamopt,fname_options,llsadv, &
                                   ibas_prf,lambda_crit,iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv,courant,peclet,ladaptive,author,&
@@ -136,7 +136,7 @@ contains
     namelist/DOMAIN/ &
         itot,jtot,kmax,kmax_soil,&
         xsize,ysize,&
-        xlat,xlon,xyear,xday,xtime,ksp,beta
+        xlat,xlon,xyear,xday,xtime,ksp,xyrot
     namelist/PHYSICS/ &
         !cstep z0,ustin,wtsurf,wqsurf,wsvsurf,ps,thls,chi_half,lmoist,isurf,lneutraldrag,&
         lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,ltimedep,ltimedepuv,ltimedepsv,ntimedep,&
@@ -239,7 +239,7 @@ contains
     call D_MPI_BCAST(xyear      ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(xday       ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(xtime      ,1,0,commwrld,mpierr)
-    call D_MPI_BCAST(beta       ,1,0,commwrld,mpierr)
+    call D_MPI_BCAST(xyrot       ,1,0,commwrld,mpierr)
 
     !call D_MPI_BCAST(lneutraldrag ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(lcoriol     ,1,0,commwrld,mpierr)

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -72,7 +72,7 @@ contains
 
     use modglobal,         only : version,initglobal,iexpnr, ltotruntime, runtime, dtmax, dtav_glob,timeav_glob,&
                                   lwarmstart,startfile,trestart,&
-                                  nsv,itot,jtot,kmax,xsize,ysize,xlat,xlon,xyear,xday,xtime,&
+                                  nsv,itot,jtot,kmax,xsize,ysize,xlat,xlon,xyear,xday,xtime,beta,&
                                   lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,cu,cv,&
                                   ifnamopt,fname_options,llsadv, &
                                   ibas_prf,lambda_crit,iadv_mom,iadv_tke,iadv_thl,iadv_qt,iadv_sv,courant,peclet,ladaptive,author,&
@@ -136,7 +136,7 @@ contains
     namelist/DOMAIN/ &
         itot,jtot,kmax,kmax_soil,&
         xsize,ysize,&
-        xlat,xlon,xyear,xday,xtime,ksp
+        xlat,xlon,xyear,xday,xtime,ksp,beta
     namelist/PHYSICS/ &
         !cstep z0,ustin,wtsurf,wqsurf,wsvsurf,ps,thls,chi_half,lmoist,isurf,lneutraldrag,&
         lcoriol,lpressgrad,igrw_damp,geodamptime,uvdamprate,lmomsubs,ltimedep,ltimedepuv,ltimedepsv,ntimedep,&
@@ -239,6 +239,7 @@ contains
     call D_MPI_BCAST(xyear      ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(xday       ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(xtime      ,1,0,commwrld,mpierr)
+    call D_MPI_BCAST(beta       ,1,0,commwrld,mpierr)
 
     !call D_MPI_BCAST(lneutraldrag ,1,0,commwrld,mpierr)
     call D_MPI_BCAST(lcoriol     ,1,0,commwrld,mpierr)


### PR DESCRIPTION
Allow for domains whose local x'y' grid is rotated with respect to the stardard East(x) North(y) grids. New parameter **xyrot** (default 0) indicates rotation angle in degrees measured positive counterclockwise. Coriolis force is then expressed in rotated x'y' basis.
- Other rotations incl. geostrophic winds, initial winds, advective tendencies, etc are _left to the user_ to calculate in pre-processing.