### PR TITLE
Fujitsu compiler fixes

### DIFF
--- a/src/modaerosol_mode_t.f90
+++ b/src/modaerosol_mode_t.f90
@@ -62,18 +62,18 @@ module modaerosol_mode_t
 
   interface
     subroutine mode_t_prepare(this, sv)
-      import :: mode_t, field_r
+      import :: mode_t, field_r, ih, jh
       class(mode_t), intent(inout) :: this
-      real(field_r), intent(in) :: sv(:,:,:,:)
+      real(field_r), intent(in) :: sv(2-ih:,2-jh:,:,:)
     end subroutine mode_t_prepare
   end interface
 
   interface
     subroutine mode_t_finish(this, svp, svm, delt)
-      import :: mode_t, field_r
+      import :: mode_t, field_r, ih, jh
       class(mode_t), intent(inout) :: this
-      real(field_r), intent(inout) :: svp(:,:,:,:)
-      real(field_r), intent(in) :: svm(:,:,:,:)
+      real(field_r), intent(inout) :: svp(2-ih:,2-jh:,:,:)
+      real(field_r), intent(in) :: svm(2-ih:,2-jh:,:,:)
       real(field_r), intent(in) :: delt
     end subroutine mode_t_finish
   end interface

--- a/src/modtranspose.f90
+++ b/src/modtranspose.f90
@@ -34,11 +34,7 @@ module modtranspose
     procedure :: z_to_y => transpose_z_to_y
   end type t_transposer
 
-#if POIS_PRECISION == 64
-  type(MPI_DATATYPE), parameter :: MPI_DTYPE = MPI_REAL8
-#else
-  type(MPI_DATATYPE), parameter :: MPI_DTYPE = MPI_REAL4
-#endif
+  type(MPI_DATATYPE) :: MPI_DTYPE
 
 contains
 
@@ -100,6 +96,12 @@ contains
     integer :: i, j, k, n, ii
     integer :: n1, n2, n3
     integer :: mpierr
+
+#if POIS_PRECISION == 64
+     MPI_DTYPE = MPI_REAL8
+#else
+     MPI_DTYPE = MPI_REAL4
+#endif
 
     if (ltimer) call timer_tic(routine, 2)
 


### PR DESCRIPTION
* don't expect MPI_REAL4 to be a compile time constant (parameter), in the Fugaku MPI it isn't.
* declare explicit lower bounds for arrays in aerosol_mode_t. Work-around for Fujitsu compiler issue under investigation.