### PR TITLE
bugfix: add missing lmoist guard on qtsurf-calls 

### DIFF
--- a/src/modgpu.f90
+++ b/src/modgpu.f90
@@ -36,7 +36,8 @@ contains
     use modthermodynamics, only: th0av, thv0, thetah, qth, qlh
     use modboundary, only: tsc
     use modmicrodata, only: precep, thlpmcr, qtpmcr
-    use modibm,      only: fluid_mask, iobst, ixw_p, ixw_m, iyw_p, iyw_m, izw_p
+    use modibm,      only: iobst, ixw_p, ixw_m, iyw_p, iyw_m, izw_p
+    use modibmdata,  only: fluid_mask
 
     implicit none
 
@@ -107,8 +108,8 @@ contains
     use modthermodynamics, only: th0av, thv0, thetah, qth, qlh
     use modboundary, only: tsc
     use modmicrodata, only: precep, thlpmcr, qtpmcr
-    use modibm,      only: fluid_mask, iobst, ixw_p, ixw_m, iyw_p, iyw_m, izw_p
-
+    use modibm,      only: iobst, ixw_p, ixw_m, iyw_p, iyw_m, izw_p
+    use modibmdata,   only: fluid_mask
     implicit none
 
     if (host_is_updated) return

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -34,7 +34,7 @@ module modibm
   use modsurface,      only : psim, psih, calc_obl_iter
   use modibmdata,      only : lapply_ibm,lpoislast, lwallheat, &
                             thlwall, qtwall, thlroof, qtroof, thlibm, qtibm, &
-                            z0m_wall, z0h_wall
+                            z0m_wall, z0h_wall, fluid_mask
   use modtimer
   use modlogging,      only : finish, warning, message
   
@@ -49,7 +49,6 @@ module modibm
   integer :: Nxwalls_plus, Nywalls_plus, Nzwalls_plus, Nxwalls_min, Nywalls_min, Nzwalls_min      !< Number of walls oriented in positve/negative x,y,z directions
   integer, allocatable :: ixw_p(:,:), ixw_m(:,:), iyw_p(:,:), iyw_m(:,:), izw_p(:,:)!, izw_m(:,:) !< Indices of walls oriented in positve/negative x,y,z directions
   integer, allocatable :: iobst(:,:)                                                              !< Indices of obstacles
-  logical, allocatable :: fluid_mask(:,:,:)                                                       !< Logical which is .false. for internal building points
   
   real(field_r) :: dx_half, dy_half, Cm_xwall, Cm_ywall, Cd_xwall, Cd_ywall, Cm_zwall, Cd_zwall, z_MO !< Additional variables/parameters
 

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -34,7 +34,7 @@ module modibm
   use modsurface,      only : psim, psih, calc_obl_iter
   use modibmdata,      only : lapply_ibm,lpoislast, lwallheat, &
                             thlwall, qtwall, thlroof, qtroof, thlibm, qtibm, &
-                            z0m_wall, z0h_wall, fluid_mask
+                            z0m_wall, z0h_wall
   use modtimer
   use modlogging,      only : finish, warning, message
   
@@ -49,6 +49,7 @@ module modibm
   integer :: Nxwalls_plus, Nywalls_plus, Nzwalls_plus, Nxwalls_min, Nywalls_min, Nzwalls_min      !< Number of walls oriented in positve/negative x,y,z directions
   integer, allocatable :: ixw_p(:,:), ixw_m(:,:), iyw_p(:,:), iyw_m(:,:), izw_p(:,:)!, izw_m(:,:) !< Indices of walls oriented in positve/negative x,y,z directions
   integer, allocatable :: iobst(:,:)                                                              !< Indices of obstacles
+  logical, allocatable :: fluid_mask(:,:,:)                                                       !< Logical which is .false. for internal building points
   
   real(field_r) :: dx_half, dy_half, Cm_xwall, Cm_ywall, Cd_xwall, Cd_ywall, Cm_zwall, Cd_zwall, z_MO !< Additional variables/parameters
 

--- a/src/modibm.f90
+++ b/src/modibm.f90
@@ -34,7 +34,7 @@ module modibm
   use modsurface,      only : psim, psih, calc_obl_iter
   use modibmdata,      only : lapply_ibm,lpoislast, lwallheat, &
                             thlwall, qtwall, thlroof, qtroof, thlibm, qtibm, &
-                            z0m_wall, z0h_wall
+                            z0m_wall, z0h_wall, fluid_mask
   use modtimer
   use modlogging,      only : finish, warning, message
   
@@ -49,11 +49,10 @@ module modibm
   integer :: Nxwalls_plus, Nywalls_plus, Nzwalls_plus, Nxwalls_min, Nywalls_min, Nzwalls_min      !< Number of walls oriented in positve/negative x,y,z directions
   integer, allocatable :: ixw_p(:,:), ixw_m(:,:), iyw_p(:,:), iyw_m(:,:), izw_p(:,:)!, izw_m(:,:) !< Indices of walls oriented in positve/negative x,y,z directions
   integer, allocatable :: iobst(:,:)                                                              !< Indices of obstacles
-  logical, allocatable :: fluid_mask(:,:,:)                                                       !< Logical which is .false. for internal building points
   
   real(field_r) :: dx_half, dy_half, Cm_xwall, Cm_ywall, Cd_xwall, Cd_ywall, Cm_zwall, Cd_zwall, z_MO !< Additional variables/parameters
 
-  public :: ibm_read_namelist, initibm, exitibm, applyibm, zerowallvelocity, fluid_mask
+  public :: ibm_read_namelist, initibm, exitibm, applyibm, zerowallvelocity
 
 contains
 

--- a/src/modibmdata.f90
+++ b/src/modibmdata.f90
@@ -29,10 +29,11 @@ module modibmdata
   implicit none
   save
 
-  logical :: lapply_ibm     = .false.        !< Switch to enable immersed boundary method 
-  logical :: lwallheat      = .false.        !< Switch to apply lateral heat flux from buildings
-  logical :: lpoislast      = .true.         !< Switch to use the Poisson solver after the Immersed boundary method
-                                             !  .false. will set the order to: ZeroVelocity -> PoissonSolver -> IBM
+  logical               :: lapply_ibm     = .false.   !< Switch to enable immersed boundary method 
+  logical               :: lwallheat      = .false.   !< Switch to apply lateral heat flux from buildings
+  logical               :: lpoislast      = .true.    !< Switch to use the Poisson solver after the Immersed boundary method
+                                                            !  .false. will set the order to: ZeroVelocity -> PoissonSolver -> IBM
+  logical, allocatable  :: fluid_mask(:,:,:)          !< Logical which is .false. for internal building points
 
   real(field_r)    :: thlwall        = 293.           !< Wall temperature at the sides of the buildings [K]
   real(field_r)    :: qtwall         = 0.             !< Wall specific humidity [kg/kg]

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -514,7 +514,8 @@ contains
     use modmpi,            only : slabsum,myid,comm3d,mpierr,D_MPI_BCAST, print_info_stderr
     use modthermodynamics, only : thermodynamics,calc_halflev, lmoist
     use moduser,           only : initsurf_user
-    use modibmdata,        only : thlibm, qtibm, lapply_ibm, fluid_mask
+    use modibm,            only : fluid_mask
+    use modibmdata,        only : thlibm, qtibm, lapply_ibm
 
     use modtestbed,        only : ltestbed,tb_ps,tb_thl,tb_qt,tb_u,tb_v,tb_w,tb_ug,tb_vg,&
                                   tb_dqtdxls,tb_dqtdyls,tb_qtadv,tb_thladv

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -514,8 +514,7 @@ contains
     use modmpi,            only : slabsum,myid,comm3d,mpierr,D_MPI_BCAST, print_info_stderr
     use modthermodynamics, only : thermodynamics,calc_halflev, lmoist
     use moduser,           only : initsurf_user
-    use modibm,            only : fluid_mask
-    use modibmdata,        only : thlibm, qtibm, lapply_ibm
+    use modibmdata,        only : thlibm, qtibm, lapply_ibm, fluid_mask
 
     use modtestbed,        only : ltestbed,tb_ps,tb_thl,tb_qt,tb_u,tb_v,tb_w,tb_ug,tb_vg,&
                                   tb_dqtdxls,tb_dqtdyls,tb_qtadv,tb_thladv

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -512,7 +512,7 @@ contains
     use modlsm,            only : init_lsm_tiles
     use modboundary,       only : boundary
     use modmpi,            only : slabsum,myid,comm3d,mpierr,D_MPI_BCAST, print_info_stderr
-    use modthermodynamics, only : thermodynamics,calc_halflev
+    use modthermodynamics, only : thermodynamics,calc_halflev, lmoist
     use moduser,           only : initsurf_user
     use modibm,            only : fluid_mask
     use modibmdata,        only : thlibm, qtibm, lapply_ibm
@@ -861,7 +861,7 @@ contains
 #if defined(_OPENACC)
       call update_gpu_surface
 #endif
-      call qtsurf
+      if (lmoist) call qtsurf
 
       dthldz(:,:) = (thlprof(1) - thls) / zf(1)
       thvs = thls * (1. + (rv/rd - 1.) * qts)

--- a/src/modstartup.f90
+++ b/src/modstartup.f90
@@ -514,9 +514,7 @@ contains
     use modmpi,            only : slabsum,myid,comm3d,mpierr,D_MPI_BCAST, print_info_stderr
     use modthermodynamics, only : thermodynamics,calc_halflev, lmoist
     use moduser,           only : initsurf_user
-    use modibm,            only : fluid_mask
-    use modibmdata,        only : thlibm, qtibm, lapply_ibm
-
+    use modibmdata,        only : thlibm, qtibm, lapply_ibm, fluid_mask
     use modtestbed,        only : ltestbed,tb_ps,tb_thl,tb_qt,tb_u,tb_v,tb_w,tb_ug,tb_vg,&
                                   tb_dqtdxls,tb_dqtdyls,tb_qtadv,tb_thladv
     use modopenboundary,   only : openboundary_ghost,openboundary_readboundary,openboundary_initfields

--- a/src/modsurface.f90
+++ b/src/modsurface.f90
@@ -68,6 +68,7 @@ module modsurface
   use modglobal,  only: ifnamopt, checknamelisterror, zf, i1, j1, i2, j2, &
                         grav, cu, cv, rd, rv
   use modmpi,     only: d_mpi_bcast, commwrld, myid
+  use modthermodynamics, only: lmoist
   use modlogging, only: finish
   use fortran_support, only: nnml_output
   implicit none
@@ -823,7 +824,7 @@ contains
         call calc_drag_coefficients
         call calc_aerodynamic_resistance
         call presc_skin_temperature
-        call qtsurf
+        if (lmoist) call qtsurf
         call calc_friction_velocity
         call calc_surface_flux
         call calc_surface_gradients
@@ -2631,7 +2632,7 @@ contains
       thls_patch = thls_patch / SNpatch
     endif
 
-    call qtsurf
+    if (lmoist) call qtsurf
 
   end subroutine do_lsm
 

--- a/src/modthermodynamics.f90
+++ b/src/modthermodynamics.f90
@@ -35,8 +35,7 @@ module modthermodynamics
   use modsurfdata,     only: qts, thls, ps, dthldz, dqtdz
   use modmpi,          only: myid, d_mpi_bcast, commwrld, slabsum
   use modmicrodata,    only: imicro, imicro_bulk3, imicro_none
-  use modibm,          only: fluid_mask
-  use modibmdata,      only: lapply_ibm
+  use modibmdata,      only: lapply_ibm, fluid_mask
   use modslabaverage,  only: slabavg
   use advec_kappa,     only: halflev_kappa
   use modprecision,    only: field_r


### PR DESCRIPTION
Safety guard to prevent unexpected qts/qskin behavior and thus influence on surface temperature when lmoist=.false.