### PR TITLE
Fix fortran-support compilation with `-fdefault-real-8`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,11 +128,11 @@ if( ENABLE_ACC )
   endif()
 endif()
 
-# Find the fortran-support library (included).
-include ( dales_add_fortran_support )
-
 # Set the compiler flags for the selected compiler
 include( dales_compile_options )
+
+# Find the fortran-support library (included).
+include ( dales_add_fortran_support )
 
 # Add RRTMGP
 include( dales_add_rrtmgp )

--- a/cmake/dales_add_fortran_support.cmake
+++ b/cmake/dales_add_fortran_support.cmake
@@ -11,6 +11,7 @@ FetchContent_Declare(
     fortran-support
     GIT_REPOSITORY "https://gitlab.dkrz.de/icon-libraries/libfortran-support.git"
     GIT_TAG 34246610b17db29f214fb2f95ca1c9087f09b89c # git tag 2.2.1
+    PATCH_COMMAND git apply --reject --whitespace=fix ${PROJECT_SOURCE_DIR}/patches/libfortran-support.patch
 )
 
 FetchContent_MakeAvailable(fortran-support)

--- a/cmake/dales_add_fortran_support.cmake
+++ b/cmake/dales_add_fortran_support.cmake
@@ -10,7 +10,7 @@ ecbuild_info( "Fetching fortran-support" )
 FetchContent_Declare(
     fortran-support
     GIT_REPOSITORY "https://gitlab.dkrz.de/icon-libraries/libfortran-support.git"
-    GIT_TAG d0d20147dfe96b41b2b8d2a9892e19aaeb3d6bbf # git tag 2.2.0
+    GIT_TAG 34246610b17db29f214fb2f95ca1c9087f09b89c # git tag 2.2.1
 )
 
 FetchContent_MakeAvailable(fortran-support)

--- a/patches/libfortran-support.patch
+++ b/patches/libfortran-support.patch
@@ -1,0 +1,30 @@
+diff --git a/src/mo_util_string.F90 b/src/mo_util_string.F90
+index 9ae064e..fa8a40a 100644
+--- a/src/mo_util_string.F90
++++ b/src/mo_util_string.F90
+@@ -15,6 +15,7 @@
+ 
+ ! String conversion utilities
+ MODULE mo_util_string
++  USE ISO_FORTRAN_ENV, ONLY: real32, real64
+   USE mo_exception, ONLY: finish
+   USE ISO_C_BINDING, ONLY: c_int8_t, c_char
+   USE mo_io_units, ONLY: MAX_CHAR_LENGTH => filename_max
+@@ -256,7 +257,7 @@ CONTAINS
+   !
+   PURE FUNCTION float2string(n, opt_fmt)
+     CHARACTER(len=32) :: float2string ! result
+-    REAL, INTENT(IN) :: n
++    REAL(real32), INTENT(IN) :: n
+     CHARACTER(len=*), INTENT(IN), OPTIONAL :: opt_fmt
+     !
+     CHARACTER(len=10) :: fmt
+@@ -273,7 +274,7 @@ CONTAINS
+   !
+   PURE FUNCTION double2string(n, opt_fmt)
+     CHARACTER(len=32) :: double2string ! result
+-    DOUBLE PRECISION, INTENT(IN) :: n
++    REAL(real64), INTENT(IN) :: n
+     CHARACTER(len=*), INTENT(IN), OPTIONAL :: opt_fmt
+     !
+     CHARACTER(len=10) :: fmt


### PR DESCRIPTION
- Updated CMake files such that our pre-defined set of compilation flags are passed to `libfortran-support`
- Patched `mo_util_string.f90` to account for `-fdefault-real-8`
- Updated `libfortran-support` to verson 2.2.1