### PR TITLE
Fix re-compilation issue with `libfortran-support`

### DIFF
--- a/cmake/dales_add_fortran_support.cmake
+++ b/cmake/dales_add_fortran_support.cmake
@@ -12,6 +12,7 @@ FetchContent_Declare(
     GIT_REPOSITORY "https://gitlab.dkrz.de/icon-libraries/libfortran-support.git"
     GIT_TAG 34246610b17db29f214fb2f95ca1c9087f09b89c # git tag 2.2.1
     PATCH_COMMAND git apply --reject --whitespace=fix ${PROJECT_SOURCE_DIR}/patches/libfortran-support.patch
+    UPDATE_DISCONNECTED TRUE
 )
 
 FetchContent_MakeAvailable(fortran-support)


### PR DESCRIPTION
Prevents CMake from performing the update step for `libfortran-support` upon rebuilds.